### PR TITLE
Change new alias syntax to `alias this : identifier`

### DIFF
--- a/declaration.dd
+++ b/declaration.dd
@@ -21,6 +21,7 @@ $(GNAME AliasInitializer):
 
 $(GNAME AliasThisDeclaration):
     $(D alias) $(I Identifier) $(D this)
+    $(B alias) $(B this) $(B :) $(I Identifier)
 
 $(GNAME Decl):
     $(GLINK StorageClasses) $(I Decl)

--- a/declaration.dd
+++ b/declaration.dd
@@ -21,7 +21,6 @@ $(GNAME AliasInitializer):
 
 $(GNAME AliasThisDeclaration):
     $(D alias) $(I Identifier) $(D this)
-    $(D alias) $(D this) $(D =) $(I Identifier)
 
 $(GNAME Decl):
     $(GLINK StorageClasses) $(I Decl)


### PR DESCRIPTION
A new alias this syntax is introduced by #177, but after that, I thought that was not good.
Then, I'd like to replace it to the syntax `alias this : identifier;`.

Reasons:
1. `alias this` is a completely different concept with normal `alias` declaration.
2. That is more consistent with the base class list `class D : C, I1, I2 {}`.
3. That is fairly easy to enhanced for the multiple alias this in the future, like `alias this : ident1, ident2;`.

How about?

Blocked by https://github.com/D-Programming-Language/dmd/pull/1341