### PR TITLE
Remove min-width to improve look on some devices

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,8 +8,7 @@ body
 	background-repeat: no-repeat;
 	font-size: 100%;
 	font-family: Verdana, "Deja Vu", "Bitstream Vera Sans", sans-serif;
-	min-width: 60em;
-    margin: 0px auto;
+	margin: 0px auto;
 }
 
 .hyphenate


### PR DESCRIPTION
When using `min-width` with `60em`, some users that use large fonts would have a very unpleasant time because the site has a horizontal scroll bar at about 950px width, which is almost the half of 1920px, which in turn is one of the more common horizontal resolutions out there. This means users who use their browser window on one half of the screen and something else (like a code editor) on the other half would have to deal with a horizontal scrollbar when none was needed.

Please let me know if this change would break someone's workflow who relies on horizontal scrollbars on dlang.org.