### PR TITLE
Fix Issue 13547 - "D is a fully garbage collected language"

### DIFF
--- a/garbage.dd
+++ b/garbage.dd
@@ -82,16 +82,16 @@ $(SPEC_S Garbage Collection,
 
 	$(UL
 
-	$(LI It is not easily predictable when a collection gets run, so the
-	program can arbitrarily pause.
+	$(LI It is not always obvious when the GC allocates memory, which in
+	turn can trigger a collection, so the program can pause unexpectedly.
 	)
 
-	$(LI The time it takes for a collection to run is not bounded. While in
-	practice it is very quick, this cannot be guaranteed.
+	$(LI The time it takes for a collection to complete is not bounded.
+	While in practice it is very quick, this cannot normally be guaranteed.
 	)
 
-	$(LI All threads other than the collector thread must be halted while
-	the collection is in progress.
+	$(LI Normally, all threads other than the collector thread must be
+	halted while the collection is in progress.
 	)
 
 	$(LI Garbage collectors can keep around some memory that an explicit

--- a/garbage.dd
+++ b/garbage.dd
@@ -2,17 +2,16 @@ Ddoc
 
 $(SPEC_S Garbage Collection,
 
-	$(P D is a systems programming language with support for a garbage collector. Usually it is not
-	necessary
+	$(P D is a systems programming language with support for garbage collection.
+	Usually it is not necessary
 	to free memory explicitly. Just allocate as needed, and the garbage collector will
 	periodically return all unused memory to the pool of available memory.
 	)
 	
 	$(P D also provides the mechanisms to write code where the garbage collector
-	is not involved. Specially important for the use cases where performace requirements forbid such use. More information
-    provided below.
+	is $(B not involved). More information is provided below.
 	)
-    
+
 	$(P C and C++ programmers accustomed to explicitly managing memory
 	allocation and
 	deallocation will likely be skeptical of the benefits and efficacy of
@@ -108,13 +107,14 @@ $(SPEC_S Garbage Collection,
 	)
 
 	$(P These constraints are addressed by techniques outlined
-	in $(DPLLINK memory.html, Memory Management). Including the mechanisms provided by
-    D to control allocations outside the GC heap.
+	in $(DPLLINK memory.html, Memory Management), including the mechanisms provided by
+	D to control allocations outside the GC heap.
 	)
     
 	$(P There is currently work in progress to make the runtime library free of GC heap allocations,
-    to allow its use in scenarios where the use of GC infrastructure is not possible.
+	to allow its use in scenarios where the use of GC infrastructure is not possible.
 	)
+
 $(H2 How Garbage Collection Works)
 
 	$(P The GC works by:)
@@ -133,7 +133,7 @@ $(H2 How Garbage Collection Works)
 
 	$(LI Freeing all GC allocated memory that has no active pointers
 	to it and do not need destructors to run.)
-	
+
 	$(LI Queueing all unreachable memory that needs destructors to run.)
 
 	$(LI Resuming all other threads.)

--- a/garbage.dd
+++ b/garbage.dd
@@ -2,12 +2,17 @@ Ddoc
 
 $(SPEC_S Garbage Collection,
 
-	$(P D is a fully garbage collected language. That means that it is never
+	$(P D is a systems programming language with support for a garbage collector. Usually it is not
 	necessary
-	to free memory. Just allocate as needed, and the garbage collector will
+	to free memory explicitly. Just allocate as needed, and the garbage collector will
 	periodically return all unused memory to the pool of available memory.
 	)
-
+	
+	$(P D also provides the mechanisms to write code where the garbage collector
+	is not involved. Specially important for the use cases where performace requirements forbid such use. More information
+    provided below.
+	)
+    
 	$(P C and C++ programmers accustomed to explicitly managing memory
 	allocation and
 	deallocation will likely be skeptical of the benefits and efficacy of
@@ -103,9 +108,13 @@ $(SPEC_S Garbage Collection,
 	)
 
 	$(P These constraints are addressed by techniques outlined
-	in $(DPLLINK memory.html, Memory Management).
+	in $(DPLLINK memory.html, Memory Management). Including the mechanisms provided by
+    D to control allocations outside the GC heap.
 	)
-
+    
+	$(P There is currently work in progress to make the runtime library free of GC heap allocations,
+    to allow its use in scenarios where the use of GC infrastructure is not possible.
+	)
 $(H2 How Garbage Collection Works)
 
 	$(P The GC works by:)
@@ -124,7 +133,7 @@ $(H2 How Garbage Collection Works)
 
 	$(LI Freeing all GC allocated memory that has no active pointers
 	to it and do not need destructors to run.)
-
+	
 	$(LI Queueing all unreachable memory that needs destructors to run.)
 
 	$(LI Resuming all other threads.)

--- a/index.dd
+++ b/index.dd
@@ -207,7 +207,8 @@ $(LI D is designed such that most "obvious" code is fast $(I and)
 safe. On occasion a function might need to escape the confines of type
 safety for ultimate speed and control. For such rare cases D offers
 native pointers, type casts, access to any C function without any
-intervening translation, and even inline assembly code. $(EXAMPLE 5,
+intervening translation, manual memory management, custom allocators
+and even inline assembly code. $(EXAMPLE 5,
 ----
 import core.stdc.stdlib;
 

--- a/overview.dd
+++ b/overview.dd
@@ -100,7 +100,7 @@ $(SECTION3 Major Design Goals of D,
 	for third party static code checkers.)
 
 	$(LI Support memory safe programming.)
-	
+
 	$(LI Support multi-paradigm programming, i.e. at a minimum support
 	imperative, structured, object oriented, generic and even
 	functional programming paradigms.)
@@ -133,7 +133,7 @@ $(SECTION3 Major Design Goals of D,
 	technology.)
 
 	$(LI Cater to the needs of numerical analysis programmers.)
-    
+
 	$(LI Obviously, sometimes these goals will conflict. Resolution will be
 	in favor of usability.)
     )
@@ -218,6 +218,13 @@ $(SECTION3 Features To Keep,
 	software.
 	)
 
+	$(LI $(B Custom memory management).
+	There are times in systems programming where developers need
+	alternatives to garbage collection. D also allows for manual memory
+	management, techniques such as reference counting, and the use of 
+	specialized memory allocators.
+	)
+
 	$(LI $(B Down and dirty programming). D retains the ability to
 	do down-and-dirty programming without resorting to referring to
 	external modules compiled in a different language. Sometimes,
@@ -225,12 +232,6 @@ $(SECTION3 Features To Keep,
 	when doing systems work. D's goal is not to $(I prevent) down
 	and dirty programming, but to minimize the need for it in
 	solving routine coding tasks.
-	)
-	
-	$(LI $(B Use of allocators and manual memory management).
-	There are many use cases in systems programming where developers need to go beyond what
-	the garbage collector offers. For those use cases, D also allows for manual memory management
-	and the use of specialized memory allocators.
 	)
 	)
 )

--- a/overview.dd
+++ b/overview.dd
@@ -100,7 +100,7 @@ $(SECTION3 Major Design Goals of D,
 	for third party static code checkers.)
 
 	$(LI Support memory safe programming.)
-
+	
 	$(LI Support multi-paradigm programming, i.e. at a minimum support
 	imperative, structured, object oriented, generic and even
 	functional programming paradigms.)
@@ -133,7 +133,7 @@ $(SECTION3 Major Design Goals of D,
 	technology.)
 
 	$(LI Cater to the needs of numerical analysis programmers.)
-
+    
 	$(LI Obviously, sometimes these goals will conflict. Resolution will be
 	in favor of usability.)
     )
@@ -226,7 +226,13 @@ $(SECTION3 Features To Keep,
 	and dirty programming, but to minimize the need for it in
 	solving routine coding tasks.
 	)
-    )
+	
+	$(LI $(B Use of allocators and manual memory management).
+	There are many use cases in systems programming where developers need to go beyond what
+	the garbage collector offers. For those use cases, D also allows for manual memory management
+	and the use of specialized memory allocators.
+	)
+	)
 )
 
 $(SECTION3 Features To Drop,


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13547

Supercedes https://github.com/D-Programming-Language/dlang.org/pull/666 - I squashed those commits together, then made the suggested edits in a separate commit. I also weakened some of the wording on downsides of GC in the 3rd commit, because:

* AIUI, the GC only collects when making an allocation (it doesn't interrupt).
* A D GC could do partial collections, preventing long pauses.
* Threads not managed by the runtime do not necessarily have to be paused when collecting garbage.