### PR TITLE
Issue 3652 - Allow explicit and implicit casting of dynamic array slices of known size to static array

### DIFF
--- a/expression.dd
+++ b/expression.dd
@@ -1056,6 +1056,46 @@ $(GNAME SliceExpression):
 
     $(P A $(I SliceExpression) is not a modifiable lvalue.)
 
+    $(P If the slice bounds can be known at compile time, the slice expression
+        is implicitly convertible to an lvalue of static array. For example:
+
+        -------------
+        arr[a .. b]     // typed T[]
+        -------------
+
+        If both $(CODE a) and $(CODE b) are integers (may be constant-folded),
+        the slice expression can be convered to a static array type
+        $(D T[b - a]).
+
+        -------------
+        void foo(int[2] a)
+        {
+            assert(a == [2, 3]);
+        }
+        void bar(ref int[2] a)
+        {
+            assert(a == [2, 3]);
+            a[0] = 4;
+            a[1] = 5;
+            assert(a == [4, 5]);
+        }
+        void baz(int[3] a) {}
+
+        void main()
+        {
+            int[] arr = [1, 2, 3];
+
+            foo(arr[1 .. 3]);
+            assert(arr == [1, 2, 3]);
+
+            bar(arr[1 .. 3]);
+            assert(arr == [1, 4, 5]);
+
+          //baz(arr[1 .. 3]); // cannot match length
+        }
+        -------------
+    )
+
     $(P If $(I PostfixExpression) is an $(I ExpressionTuple), then
         the result of the slice is a new $(I ExpressionTuple) formed
         from the upper and lower bounds, which must statically evaluate
@@ -1207,6 +1247,31 @@ $(GNAME StringLiterals):
         $(TROW $(D immutable(dchar)[]))
     )
 
+    $(P By default, a string literal is typed as a dynamic array, but the element
+        count is known at compile time. So all string literals can be
+        implicitly convered to static array types.
+
+        -------------
+        void foo(char[2] a)
+        {
+            assert(a == "bc");
+        }
+        void bar(ref const char[2] a)
+        {
+            assert(a == "bc");
+        }
+        void baz(const char[3] a) {}
+
+        void main()
+        {
+            string str = "abc";
+            foo(str[1 .. 3]);
+            bar(str[1 .. 3]);
+          //baz(str[1 .. 3]); // cannot match length
+        }
+        -------------
+    )
+
     $(P String literals have a 0 appended to them, which makes
         them easy to pass to C or C++ functions expecting a $(CODE const char*)
         string.
@@ -1233,6 +1298,39 @@ $(GNAME ArrayLiteral):
         auto a1 = [1,2,3];  // type is int[], with elements 1, 2 and 3
         auto a2 = [1u,2,3]; // type is uint[], with elements 1u, 2u, and 3u
         ---
+    )
+
+    $(P By default, an array literal is typed as a dynamic array, but the element
+        count is known at compile time. So all array literals can be
+        implicitly convered to static array types.
+
+        -------------
+        void foo(long[2] a)
+        {
+            assert(a == [2, 3]);
+        }
+        void bar(ref long[2] a)
+        {
+            assert(a == [2, 3]);
+            a[0] = 4;
+            a[1] = 5;
+            assert(a == [4, 5]);
+        }
+        void baz(const char[3] a) {}
+
+        void main()
+        {
+            long[] arr = [1, 2, 3];
+
+            foo(arr[1 .. 3]);
+            assert(arr == [1, 2, 3]);
+
+            bar(arr[1 .. 3]);
+            assert(arr == [1, 4, 5]);
+
+          //baz(arr[1 .. 3]); // cannot match length
+        }
+        -------------
     )
 
     $(P If any of the arguments in the $(GLINK ArgumentList) are


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=3652

Even if a poor D compiler does not support any const-folding, `arr[1 .. 3]` should be convertible to `T[2]`. This PR will add the minimum requirement for the feature.