### PR TITLE
Use hierarchical Jump-to links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -735,6 +735,11 @@ TABLE.book CAPTION
     text-align: left;
 }
 
+.quickindex {
+	font-weight: normal;
+	background-color: #E4E9EF;
+}
+
 .question
 {
     display: inline;

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -64,7 +64,7 @@ DDOC_SECTION   = $0$(P)
 DDOC_PARAMS    = $(B Parameters:)<table class=parms>$0</table>$(P)
 DDOC_BLANKLINE	= $(P)
 DDOC_PSYMBOL = <a name="$0"></a><span class="ddoc_psymbol">$0</span>
-DDOC_ANCHOR = $(SCRIPT defineSymbol("$0");)$(ADEF .$0)
+DDOC_ANCHOR = $(ADEF .$1)$(DIVCID quickindex, quickindex.$1, )
 DDOC_DECL  = <dt class="d_decl">$0</dt>
 DDOCCODE=<pre class="ddoccode notranslate">$0</pre>
 DDSUBLINK=$(XLINK2 $1.html#$2, $3)

--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -1,0 +1,51 @@
+/**
+Generates 'Jump to' links.
+
+Copyright: 1999-2014 by Digital Mars
+
+License:   http://boost.org/LICENSE_1_0.txt, Boost License 1.0
+
+Authors:   Andrei Alexandrescu, Nick Treleaven
+*/
+
+/* Symbol definition */
+var lastSymbolDefined = '';
+var values = [];
+//
+function lastName(a) {
+    var pos = a.lastIndexOf('.');
+    return a.slice(pos + 1);
+}
+//
+function defineSymbol(sym) {
+  // ignore ditto overloads
+  if (sym == lastSymbolDefined) return;
+  // ignore foo.bar, foo.bar.2, but show foo, foo.2
+  var pos = sym.indexOf('.');
+  if (pos >= 0 && (sym.lastIndexOf('.') != pos || isNaN(lastName(sym)))) return;
+  // Note: empty comment avoids ddoc macro definition
+  /**/ lastSymbolDefined = sym;
+  values.push(sym);
+}
+//
+function listanchors()
+{
+    if (typeof inhibitQuickIndex !== 'undefined') return;
+    var a = document.getElementById("quickindex");
+    if (!a) return;
+
+    values.sort();
+
+    var newText = "";
+    for (var i = 0; i < values.length; i++) {
+        var a = values[i];
+        var text = a;
+        if (i != 0) newText += " &middot;"; 
+        newText += ' \x3Ca class="jumpto" href="\x23.' + a +
+            '"\x3E\x3Cspan class="notranslate donthyphenate"\x3E' + text + '\x3C/span\x3E\x3C/a\x3E';
+    }
+    /**/ values = null; // unreference memory
+    if (newText != "") newText = "\x3Cp\x3E\x3Cb\x3EJump to:\x3C/b\x3E" + newText + "\x3C/p\x3E";
+    var a = document.getElementById("quickindex");
+    a.innerHTML = newText;
+}

--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -8,43 +8,64 @@ License:   http://boost.org/LICENSE_1_0.txt, Boost License 1.0
 Authors:   Andrei Alexandrescu, Nick Treleaven
 */
 
-/* Symbol definition */
-var lastSymbolDefined = '';
-var values = [];
-//
 function lastName(a) {
     var pos = a.lastIndexOf('.');
     return a.slice(pos + 1);
 }
-//
-function defineSymbol(sym) {
-  // ignore ditto overloads
-  if (sym == lastSymbolDefined) return;
-  // ignore foo.bar, foo.bar.2, but show foo, foo.2
-  var pos = sym.indexOf('.');
-  if (pos >= 0 && (sym.lastIndexOf('.') != pos || isNaN(lastName(sym)))) return;
-  lastSymbolDefined = sym;
-  values.push(sym);
-}
-//
+
 function listanchors()
 {
-    if (typeof inhibitQuickIndex !== 'undefined') return;
+    var hideTop = (typeof inhibitQuickIndex !== 'undefined');
     var a = document.getElementById("quickindex");
     if (!a) return;
 
-    values.sort();
-
-    var newText = "";
-    for (var i = 0; i < values.length; i++) {
-        var a = values[i];
-        var text = a;
-        if (i != 0) newText += " &middot;"; 
-        newText += ' <a class="jumpto" href="#.' + a +
-            '"><span class="notranslate donthyphenate">' + text + '</span></a>';
+    // build hash of parent anchor names -> array of child anchor names
+    var parentNames = [];
+    var lastAnchor = '';
+    var items = document.getElementsByClassName('quickindex');
+    for (var i = 0; i < items.length; i++)
+    {
+        var text = items[i].id;
+        // ignore top-level quickindex
+        var pos = text.indexOf('.');
+        if (pos < 0) continue;
+        // skip 'quickindex'
+        text = text.slice(pos);
+        // ignore any ditto overloads (which have the same anchor name)
+        if (text == lastAnchor) continue;
+        lastAnchor = text;
+        
+        var pos = text.lastIndexOf('.');
+        if (hideTop && pos == 0) continue;
+        var parent = (pos == 0) ? '' : text.slice(0, pos);
+        
+        if (!parentNames[parent])
+            parentNames[parent] = [text];
+        else
+            parentNames[parent].push(text);
     }
-    values = null; // unreference memory
-    if (newText != "") newText = "<p><b>Jump to:</b>" + newText + "</p>";
-    var a = document.getElementById("quickindex");
-    a.innerHTML = newText;
+    // populate quickindex elements
+    for (var key in parentNames)
+    {
+        var arr = parentNames[key];
+        // we won't display the qualifying names to save space, so sort by last name
+        arr.sort(function(a,b){
+            var aa = lastName(a).toLowerCase();
+            var bb = lastName(b).toLowerCase();
+            return aa == bb ? 0 : (aa < bb ? -1 : 1);
+        });
+        var newText = "";
+        for (var i = 0; i < arr.length; i++) {
+            var a = arr[i];
+            var text = lastName(a);
+            if (i != 0) newText += " &middot;"; 
+            newText += ' <a class="jumpto" href="#' + a +
+                '"><span class="notranslate donthyphenate">' + text + '</span></a>';
+        }
+        if (newText != "") newText = "<p><b>Jump to:</b>" + newText + "</p>";
+        var id = 'quickindex';
+        id += key;
+        var e = document.getElementById(id);
+        e.innerHTML = newText;
+    }
 }

--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -59,10 +59,14 @@ function listanchors()
             var a = arr[i];
             var text = lastName(a);
             if (i != 0) newText += " &middot;"; 
-            newText += ' <a class="jumpto" href="#' + a +
-                '"><span class="notranslate donthyphenate">' + text + '</span></a>';
+            newText += ' <a href="#' + a +
+                '">' + text + '</a>';
         }
-        if (newText != "") newText = "<p><b>Jump to:</b>" + newText + "</p>";
+        if (newText != "")
+        {
+            newText = '<p><b>Jump to:</b><span class="jumpto notranslate donthyphenate">' +
+                newText + '</span></p>';
+        }
         var id = 'quickindex';
         id += key;
         var e = document.getElementById(id);

--- a/js/listanchors.js
+++ b/js/listanchors.js
@@ -23,8 +23,7 @@ function defineSymbol(sym) {
   // ignore foo.bar, foo.bar.2, but show foo, foo.2
   var pos = sym.indexOf('.');
   if (pos >= 0 && (sym.lastIndexOf('.') != pos || isNaN(lastName(sym)))) return;
-  // Note: empty comment avoids ddoc macro definition
-  /**/ lastSymbolDefined = sym;
+  lastSymbolDefined = sym;
   values.push(sym);
 }
 //
@@ -41,11 +40,11 @@ function listanchors()
         var a = values[i];
         var text = a;
         if (i != 0) newText += " &middot;"; 
-        newText += ' \x3Ca class="jumpto" href="\x23.' + a +
-            '"\x3E\x3Cspan class="notranslate donthyphenate"\x3E' + text + '\x3C/span\x3E\x3C/a\x3E';
+        newText += ' <a class="jumpto" href="#.' + a +
+            '"><span class="notranslate donthyphenate">' + text + '</span></a>';
     }
-    /**/ values = null; // unreference memory
-    if (newText != "") newText = "\x3Cp\x3E\x3Cb\x3EJump to:\x3C/b\x3E" + newText + "\x3C/p\x3E";
+    values = null; // unreference memory
+    if (newText != "") newText = "<p><b>Jump to:</b>" + newText + "</p>";
     var a = document.getElementById("quickindex");
     a.innerHTML = newText;
 }

--- a/posix.mak
+++ b/posix.mak
@@ -99,7 +99,7 @@ module.png package.png private.png property.png protected.png		\
 struct.png template.png tree-item-closed.png tree-item-open.png		\
 variable.png)
 
-JAVASCRIPT=$(addprefix js/, codemirror-compressed.js run.js	\
+JAVASCRIPT=$(addprefix js/, codemirror-compressed.js listanchors.js run.js	\
 run-main-website.js ddox.js)
 
 STYLES=css/style.css css/print.css css/codemirror.css css/ddox.css

--- a/std.ddoc
+++ b/std.ddoc
@@ -14,48 +14,8 @@ DDOC = <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
 <script src="/js/codemirror-compressed.js"></script>
 <script src="/js/run.js" type="text/javascript"></script>
+<script src="../js/listanchors.js" type="text/javascript"></script>
 <script type="text/javascript">
-/* Symbol definition */
-var lastSymbolDefined = '';
-var values = [];
-//
-function lastName(a) {
-    var pos = a.lastIndexOf('.');
-    return a.slice(pos + 1);
-}
-//
-function defineSymbol(sym) {
-  // ignore ditto overloads
-  if (sym == lastSymbolDefined) return;
-  // ignore foo.bar, foo.bar.2, but show foo, foo.2
-  var pos = sym.indexOf('.');
-  if (pos >= 0 && (sym.lastIndexOf('.') != pos || isNaN(lastName(sym)))) return;
-  // Note: empty comment avoids ddoc macro definition
-  /**/ lastSymbolDefined = sym;
-  values.push(sym);
-}
-//
-function listanchors()
-{
-    if (typeof inhibitQuickIndex !== 'undefined') return;
-    var a = document.getElementById("quickindex");
-    if (!a) return;
-
-    values.sort();
-
-    var newText = "";
-    for (var i = 0; i < values.length; i++) {
-        var a = values[i];
-        var text = a;
-        if (i != 0) newText += " $(MIDDOT)"; 
-        newText += ' \x3Ca class="jumpto" href="\x23.' + a +
-            '"\x3E\x3Cspan class="notranslate donthyphenate"\x3E' + text + '\x3C/span\x3E\x3C/a\x3E';
-    }
-    /**/ values = null; // unreference memory
-    if (newText != "") newText = "\x3Cp\x3E\x3Cb\x3EJump to:\x3C/b\x3E" + newText + "\x3C/p\x3E";
-    var a = document.getElementById("quickindex");
-    a.innerHTML = newText;
-}
 jQuery(document).ready(listanchors);
 </script>
 </head>

--- a/std.ddoc
+++ b/std.ddoc
@@ -19,7 +19,7 @@ DDOC = <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
 var lastSymbolDefined = '';
 var values = [];
 //
-var lastName = function(a){
+function lastName(a) {
     var pos = a.lastIndexOf('.');
     return a.slice(pos + 1);
 }
@@ -27,10 +27,10 @@ var lastName = function(a){
 function defineSymbol(sym) {
   // ignore ditto overloads
   if (sym == lastSymbolDefined) return;
-  // ignore scoped symbols, but show module-level overloads
+  // ignore foo.bar, foo.bar.2, but show foo, foo.2
   var pos = sym.indexOf('.');
   if (pos >= 0 && (sym.lastIndexOf('.') != pos || isNaN(lastName(sym)))) return;
-  // Note: empty comment avoids macro def
+  // Note: empty comment avoids ddoc macro definition
   /**/ lastSymbolDefined = sym;
   values.push(sym);
 }
@@ -44,7 +44,7 @@ function listanchors()
     values.sort();
 
     var newText = "";
-    for (var i in values) {
+    for (var i = 0; i < values.length; i++) {
         var a = values[i];
         var text = a;
         if (i != 0) newText += " $(MIDDOT)"; 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=5136

Show only top-level symbols in the main module jump-to links, with remaining symbols shown in separate jump-to lists before their respective parents.

Show non-top-level jump-to links even when `inhibitQuickIndex` is set.
Show all jump-to links with same background color as symbol declarations.

Note: std.typecons, std.stdio and std.container.rbtree are nice modules to test this with.