### PR TITLE
fix order of pattern rules

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -247,16 +247,16 @@ dlangspec.verbatim.txt : macros.ddoc verbatim.ddoc dlangspec-consolidated.d
 # Git clone rules
 ################################################################################
 
-../%/.cloned :
-	[ -d $(@D) ] || git clone --depth=1 ${GIT_HOME}/$* $(@D)/
-	touch $@
-
 ../%-${LATEST}/.cloned :
 	[ -d $(@D) ] || git clone -b v${LATEST} --depth=1 ${GIT_HOME}/$* $(@D)/
 	touch $@
 
 ../%-${DUB_VER}/.cloned :
 	[ -d $(@D) ] || git clone -b v${DUB_VER} --depth=1 ${GIT_HOME}/$* $(@D)/
+	touch $@
+
+../%/.cloned :
+	[ -d $(@D) ] || git clone --depth=1 ${GIT_HOME}/$* $(@D)/
 	touch $@
 
 ################################################################################


### PR DESCRIPTION
- pre-3.8.2 make uses first matching pattern rule
- since 3.8.2. best match is used