### PR TITLE
Add XREF2 macro

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -191,7 +191,8 @@ UNDERSCORE=_
 VERTROW=$(TR $(TDX $1, $+))
 
 XLINK2=$(LINK2 $1,$+)
-XREF = <a href="http://dlang.org/phobos/std_$1.html#$2">$(D std.$1.$2)</a>
+XREF = $(XREF2 $1, $2, $(D std.$1.$2))
+XREF2 = <a href="http://dlang.org/phobos/std_$1.html#$2">$3</a>
 
 YES=$(CHECKMARK)
 


### PR DESCRIPTION
In a recent PR for Phobos (https://github.com/D-Programming-Language/phobos/pull/2817) I was advised not to use LINK2 for a link and that FULL_XREF would be better. Unfortunately, I borked the syntax. After figuring out where all the relevant macros are defined, I learned that FULL_XREF isn't what I want anyway. It simply passes its arguments on to XREF as-is. XREF creates a link to $2, also using $2 as the link text. In the context of my PR, I don't want $2 as the link text (i.e., I want the text to be "forward range" rather than "isForwardRange.") To avoid going back to LINK2, which is easily broken, I've added the macro XREF2 which takes three args like this:
```
$(XREF2 range, isForwardRange, forward range) 
```
And gives me the format I want.
