### PR TITLE
Remove comment about a beta testing on the front page

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -5,10 +5,6 @@ $(D_S D Programming Language,
 $(SECTION3 The D programming language. Modern
 convenience. Modeling power. Native efficiency.,
 
-Beta Testing in progress:
-$(UL
-$(LI $(LINK2 http://wiki.dlang.org/Beta_Testing#Available_Downloads, $(B<font color=red>DMD v2.067.0-b1</font>))))
-
 Conference videos and slides:
 $(UL
 $(LI $(LINK2 https://archive.org/search.php?query=title%3A%28DConf%202014%29&sort=+publicdate, $(B<font color=red>DConf 2014</font>)))


### PR DESCRIPTION
It's currently stall and could be misleading to users.