### PR TITLE
Issue 6574 - Erroneous recursive call in template instantiation

### DIFF
--- a/abi.dd
+++ b/abi.dd
@@ -243,6 +243,10 @@ $(GNAME TemplateArgs):
     $(GLINK TemplateArg) $(I TemplateArgs)
 
 $(GNAME TemplateArg):
+    $(GLINK TemplateArgX)
+    $(B H) $(GLINK TemplateArgX)
+
+$(GNAME TemplateArgX):
     $(B T) $(GLINK Type)
     $(B V) $(GLINK Type) $(GLINK Value)
     $(B S) $(GLINK LName)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=6574

Improve mangling scheme to distinguish instantiations with specialized template parameters.

If a template argument matches to specialized template parameter, the argument is mangled with prefix 'H'.