### PR TITLE
Verbatim ddoc generation

### DIFF
--- a/std.ddoc
+++ b/std.ddoc
@@ -86,4 +86,5 @@ TABLE = <table cellspacing=0 cellpadding=5><caption>$1</caption>$2</table>
 TD = <td valign=top>$0</td>
 TDNW = <td valign=top class="donthyphenate" nowrap>$0</td>
 SUB_IS_DEPRECATED=kept for compatibility, but collides with SUB=&sub; use SUBSCRIPT instead (this is a comment and can be changed into one if ddoc files ever start supporting comments)
+MYREF = <font face='Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace'><a href="#.$1">$1</a>&nbsp;</font>
 _=


### PR DESCRIPTION
Target `verbatim` generates for each ddoc-generated file a corresponding verbatim file, i.e. the file with all macros as they are seen and expanded by ddoc. The '.verbatim' extension replaces the '.html' extension, e.g. http://dlang.org/phobos-prerelease/std_algorithm.verbatim coresponds to http://dlang.org/phobos-prerelease/std_algorithm.html.