### PR TITLE
Document the new backticked inline code feature in ddoc

### DIFF
--- a/ddoc.dd
+++ b/ddoc.dd
@@ -485,6 +485,35 @@ $(P
     so that $(D_COMMENT /* ... */) can be used inside the code section.
 )
 
+$(H4 Inline Code)
+
+$(P
+    Inline code can be written between backtick characters ($(BACKTICK)), similarly
+    to the syntax used on GitHub, Reddit, Stack Overflow, and other websites. Both
+    the opening and closing ` character must appear on the same line to trigger this
+    behavior.
+)
+
+$(P
+    Text inside these sections will be escaped according to the rules described above,
+    then wrapped in a $(DOLLAR)(DDOC_BACKQUOTED) macro. By default, this macro expands
+    to be displayed as an inline text span, formatted as code.
+)
+
+$(P
+    A literal backtick character can be output either as a non-paired ` on a single
+    line or by using the $(BACKTICK) macro.
+)
+
+---
+ /// Returns `true` if `a == b`.
+ void foo() {}
+
+ /// Backquoted `<html>` will be displayed to the user instead
+ /// of passed through as embedded HTML (see below).
+ void bar() {}
+---
+
 $(H4 Embedded HTML)
 
 $(P


### PR DESCRIPTION
This is current with both of my recent dmd pull requests.