### PR TITLE
Add DDOC_UNDEFINED_MACRO as a comment in the generated file

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -72,6 +72,7 @@ DDOC_BLANKLINE	= $(P)
 DDOC_PSYMBOL = <a name="$0"></a><span class="ddoc_psymbol">$0</span>
 DDOC_ANCHOR = $(ADEF .$1)$(DIVCID quickindex, quickindex.$1, )
 DDOC_DECL  = <dt class="d_decl">$0</dt>
+DDOC_UNDEFINED_MACRO = $(DDOC_COMMENT UNDEFINED MACRO: "$1")
 DDOCCODE=<pre class="ddoccode notranslate">$0</pre>
 DDSUBLINK=$(XLINK2 $1.html#$2, $3)
 DRUNTIMESRC=$(HTTPS github.com/D-Programming-Language/druntime/blob/master/src/$0, $0)


### PR DESCRIPTION
This helps us weed undefined macros by just grepping through the generated content.