### PR TITLE
Issue 10285 - Enum grammar documentation is incorrect

### DIFF
--- a/enum.dd
+++ b/enum.dd
@@ -4,44 +4,45 @@ $(SPEC_S Enums,
 
 $(GRAMMAR
 $(GNAME EnumDeclaration):
-    $(D enum) $(GLINK EnumTag) $(GLINK EnumBody)
-    $(D enum) $(GLINK EnumBody)
-    $(D enum) $(GLINK EnumTag) $(D :) $(GLINK EnumBaseType) $(GLINK EnumBody)
-    $(D enum) $(D :) $(GLINK EnumBaseType) $(GLINK EnumBody)
-
-$(GNAME EnumTag):
-    $(I Identifier)
+    $(D enum) $(I Identifier) $(GLINK EnumBody)
+    $(D enum) $(I Identifier) $(D :) $(GLINK EnumBaseType) $(GLINK EnumBody)
+    $(AnonymousEnumDeclaration)
 
 $(GNAME EnumBaseType):
-    $(GLINK2 declaration, Type)
+    $(GLINK Type)
 
 $(GNAME EnumBody):
-    $(GLINK EmptyEnumBody)
-    $(GLINK EnumMembersBody)
-
-$(GNAME EmptyEnumBody):
-    $(D ;)
-
-$(GNAME EnumMembersBody):
     $(D {) $(GLINK EnumMembers) $(D })
+    $(D ;)
 
 $(GNAME EnumMembers):
     $(GLINK EnumMember)
     $(GLINK EnumMember) $(D ,)
-    $(GLINK EnumMember) $(D ,) $(I EnumMembers)
 
 $(GNAME EnumMember):
     $(I Identifier)
     $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
-    $(GLINK2 declaration, Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
+
+$(GNAME AnonymousEnumDeclaration):
+    $(D enum) $(D :) $(GLINK EnumBaseType) $(D {) $(GLINK EnumMembers) $(D })
+    $(D enum) $(D {) $(GLINK EnumMembers) $(D })
+    $(D enum) $(D {) $(GLINK AnonymousEnumMembers) $(D })
+
+$(GNAME AnonymousEnumMembers):
+    $(GLINK AnonymousEnumMember)
+    $(GLINK AnonymousEnumMembers) $(D ,) $(GLINK AnonymousEnumMember)
+
+$(GNAME AnonymousEnumMember):
+    $(GLINK EnumMember)
+    $(GLINK Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
 )
 
 	$(P Enum declarations are used to define a group of constants.
 	They come in these forms:
 	)
 	$(OL
-	$(LI Named enums, which have an $(I EnumTag).)
-	$(LI Anonymous enums, which do not have an $(I EnumTag).)
+	$(LI Named enums, which have a name.)
+	$(LI Anonymous enums, which do not have a name.)
 	$(LI Manifest constants.)
 	)
 
@@ -50,10 +51,8 @@ $(H2 Named Enums)
 	$(P
 	Named enums are used to declare related
 	constants and group them by giving them a unique type.
-	The $(I EnumMembers)
-	are declared in the scope of the enum $(I EnumTag).
-	The enum $(I EnumTag) declares a new type, and all
-	the $(I EnumMembers) have that type.
+	The $(I EnumMembers) are declared in the scope of the named enum. The named
+	enum declares a new type, and all the $(I EnumMembers) have that type.
 	)
 
 	$(P This defines a new type $(CODE X) which has values
@@ -171,7 +170,8 @@ $(H2 Anonymous Enums)
 	)
 
 	$(OL
-	$(LI The $(I Type), if present.)
+	$(LI The $(I Type), if present. Types are not permitted when an
+		$(I EnumBaseType) is present.)
 	$(LI The $(I EnumBaseType), if present.)
 	$(LI The type of the $(I AssignExpression), if present.)
 	$(LI The type of the previous $(I EnumMember), if present.)
@@ -250,12 +250,12 @@ enum long l = 3; // l is 3 of type long
 
 	$(P Such declarations are not lvalues, meaning their address
 	cannot be taken.  They exist only in the memory of the compiler.)
-	
+
 ---
 enum size = __traits(classInstanceSize, Foo);  // evaluated at compile-time
 ---
-	
-	$(P Using manifest constants is an idiomatic D method 
+
+	$(P Using manifest constants is an idiomatic D method
 	to force compile-time evaluation of an expression.)
 
 

--- a/enum.dd
+++ b/enum.dd
@@ -9,7 +9,7 @@ $(GNAME EnumDeclaration):
     $(AnonymousEnumDeclaration)
 
 $(GNAME EnumBaseType):
-    $(GLINK Type)
+    $(GLINK2 declaration, Type)
 
 $(GNAME EnumBody):
     $(D {) $(GLINK EnumMembers) $(D })
@@ -18,6 +18,7 @@ $(GNAME EnumBody):
 $(GNAME EnumMembers):
     $(GLINK EnumMember)
     $(GLINK EnumMember) $(D ,)
+    $(GLINK EnumMember) $(D ,) $(GLINK EnumMembers)
 
 $(GNAME EnumMember):
     $(I Identifier)
@@ -30,11 +31,12 @@ $(GNAME AnonymousEnumDeclaration):
 
 $(GNAME AnonymousEnumMembers):
     $(GLINK AnonymousEnumMember)
-    $(GLINK AnonymousEnumMembers) $(D ,) $(GLINK AnonymousEnumMember)
+    $(GLINK AnonymousEnumMember) $(D ,)
+    $(GLINK AnonymousEnumMember) $(D ,) $(GLINK AnonymousEnumMembers)
 
 $(GNAME AnonymousEnumMember):
     $(GLINK EnumMember)
-    $(GLINK Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
+    $(GLINK2 declaration Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
 )
 
 	$(P Enum declarations are used to define a group of constants.
@@ -115,8 +117,8 @@ enum E : C
 ---
 
 
-	$(P An $(I EmptyEnumBody) signifies an opaque enum - the enum members are
-	unknown.)
+	$(P An empty enum body (For example $(CODE enum E;)) signifies an opaque
+	enum - the enum members are unknown.)
 
 $(H3 Enum Default Initializer)
 

--- a/grammar.dd
+++ b/grammar.dd
@@ -1363,35 +1363,36 @@ $(H3 $(LNAME2 enum, Enum))
 
 $(GRAMMAR
 $(GNAME EnumDeclaration):
-    $(D enum) $(GLINK EnumTag) $(GLINK EnumBody)
-    $(D enum) $(GLINK EnumBody)
-    $(D enum) $(GLINK EnumTag) $(D :) $(GLINK EnumBaseType) $(GLINK EnumBody)
-    $(D enum) $(D :) $(GLINK EnumBaseType) $(GLINK EnumBody)
-
-$(GNAME EnumTag):
-    $(I Identifier)
+    $(D enum) $(I Identifier) $(GLINK EnumBody)
+    $(D enum) $(I Identifier) $(D :) $(GLINK EnumBaseType) $(GLINK EnumBody)
+    $(AnonymousEnumDeclaration)
 
 $(GNAME EnumBaseType):
     $(GLINK Type)
 
 $(GNAME EnumBody):
-    $(GLINK EmptyEnumBody)
-    $(GLINK EnumMembersBody)
-
-$(GNAME EmptyEnumBody):
-    $(D ;)
-
-$(GNAME EnumMembersBody):
     $(D {) $(GLINK EnumMembers) $(D })
+    $(D ;)
 
 $(GNAME EnumMembers):
     $(GLINK EnumMember)
     $(GLINK EnumMember) $(D ,)
-    $(GLINK EnumMember) $(D ,) $(I EnumMembers)
 
 $(GNAME EnumMember):
     $(I Identifier)
     $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
+
+$(GNAME AnonymousEnumDeclaration):
+    $(D enum) $(D :) $(GLINK EnumBaseType) $(D {) $(GLINK EnumMembers) $(D })
+    $(D enum) $(D {) $(GLINK EnumMembers) $(D })
+    $(D enum) $(D {) $(GLINK AnonymousEnumMembers) $(D })
+
+$(GNAME AnonymousEnumMembers):
+    $(GLINK AnonymousEnumMember)
+    $(GLINK AnonymousEnumMembers) $(D ,) $(GLINK AnonymousEnumMember)
+
+$(GNAME AnonymousEnumMember):
+    $(GLINK EnumMember)
     $(GLINK Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
 )
 

--- a/grammar.dd
+++ b/grammar.dd
@@ -1368,7 +1368,7 @@ $(GNAME EnumDeclaration):
     $(AnonymousEnumDeclaration)
 
 $(GNAME EnumBaseType):
-    $(GLINK Type)
+    $(GLINK2 declaration, Type)
 
 $(GNAME EnumBody):
     $(D {) $(GLINK EnumMembers) $(D })
@@ -1377,6 +1377,7 @@ $(GNAME EnumBody):
 $(GNAME EnumMembers):
     $(GLINK EnumMember)
     $(GLINK EnumMember) $(D ,)
+    $(GLINK EnumMember) $(D ,) $(GLINK EnumMembers)
 
 $(GNAME EnumMember):
     $(I Identifier)
@@ -1389,11 +1390,12 @@ $(GNAME AnonymousEnumDeclaration):
 
 $(GNAME AnonymousEnumMembers):
     $(GLINK AnonymousEnumMember)
-    $(GLINK AnonymousEnumMembers) $(D ,) $(GLINK AnonymousEnumMember)
+    $(GLINK AnonymousEnumMember) $(D ,)
+    $(GLINK AnonymousEnumMember) $(D ,) $(GLINK AnonymousEnumMembers)
 
 $(GNAME AnonymousEnumMember):
     $(GLINK EnumMember)
-    $(GLINK Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
+    $(GLINK2 declaration Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
 )
 
 $(H3 $(LNAME2 template, Template))


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=10285

This cleans up the enum declaration grammar and makes it more closely match DMD's implementation. Some rules that consisted of a single token were removed, and a new AnonymousEnumDeclaration rule was added to ensure that the "type identifer = assignExpression" syntax cannot appear in non-anonymous or typed enums.