### PR TITLE
mobile tweaks - hide sidebars if small screen, use mobile nav to compensate

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -959,3 +959,44 @@ input.runButton:active, input.resetButton:active, input.argsButton:active, input
 { position: relative; top: 1px; }
 input.resetButton{display: none}
 /* Runnable-examples css -end */
+
+/* Mobile related tweaks */
+
+#twitter ~ #content {
+	/* Makes room for the twitter thing only if it is actually there */
+	margin-right: 20em;
+}
+
+/* Only show twitter sidebar on an especially wide screen */
+@media screen and (max-width: 960px) {
+	#twitter {
+		display: none;
+	}
+	#twitter ~ #content {
+		margin-right: 0.5em;
+	}
+}
+
+#header-tinyscreen {
+	display: none;
+}
+
+/* Also hide the navigation sidebar on a smaller screen */
+@media screen and (max-width: 640px) {
+	#header {
+		display: none;
+	}
+
+	#header-tinyscreen {
+		display: block;
+	}
+		
+	div#navigation {
+		display: none;
+	}
+	div#content {
+		margin-left: 0.5em;
+	}
+}
+
+/* End mobile tweaks */

--- a/index.dd
+++ b/index.dd
@@ -564,7 +564,7 @@ $(TAG2 div, id="a$1" class="answer-nojs", $2)
 <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/D_Programming" data-widget-id="358057551562162176">Tweets by @D_Programming</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 </div>
-<div id="content" style="margin-right:20em;" class="hyphenate">
+<div id="content" class="hyphenate">
   $(PAGE_TOOLS)
   $3
 </div>

--- a/mobilenav.dd
+++ b/mobilenav.dd
@@ -1,0 +1,7 @@
+Ddoc
+
+$(DIVID navigation, $(TOP) $(NAVIGATION_PHOBOS))
+
+Macros:
+	TITLE=Navigation
+

--- a/posix.mak
+++ b/posix.mak
@@ -139,7 +139,7 @@ PAGES_ROOT=$(SPEC_ROOT) 32-64-portability acknowledgements ascii-table		\
 	download dstyle exception-safe faq features2 glossary gsoc2011 gsoc2012	\
 	gsoc2012-template hijack howto-promote htod htomodule index intro	\
 	intro-to-datetime lazy-evaluation memory migrate-to-shared mixin	\
-	overview pretod rationale rdmd regular-expression safed			\
+	mobilenav overview pretod rationale rdmd regular-expression safed			\
 	std_consolidated_header template-comparison templates-revisited tuple	\
 	variadic-function-templates warnings wc windbg windows
 

--- a/std.ddoc
+++ b/std.ddoc
@@ -39,6 +39,10 @@ $(DIVID top,
 		<a href="/"><img id="logo" width="125" height="95" border="0" alt="D Logo" src="/images/dlogo.png"></a>
 		<a id="d-language" href="/">D Programming Language</a>
 	</div>
+	<div id="header-tinyscreen">
+		<a href="/mobilenav.html"><img id="logo" width="125" height="95" border="0" alt="D Logo" src="/images/dlogo.png"></a>
+		<a id="d-language" href="/mobilenav.html">D Programming Language</a>
+	</div>
 )
 $(DIVID navigation, $(TOP) $(NAVIGATION_PHOBOS))
 $(DIVID content, 

--- a/win32.mak
+++ b/win32.mak
@@ -14,7 +14,7 @@ SRC= $(SPECSRC) cpptod.dd ctod.dd pretod.dd cppcontracts.dd index.dd overview.dd
 	tuple.dd template-comparison.dd COM.dd hijack.dd features2.dd safed.dd	\
 	const-faq.dd concepts.dd d-floating-point.dd migrate-to-shared.dd	\
 	D1toD2.dd intro-to-datetime.dd simd.dd deprecate.dd download.dd		\
-	32-64-portability.dd dll-linux.dd bugstats.php.dd
+	32-64-portability.dd dll-linux.dd bugstats.php.dd mobilenav.dd
 
 SPECSRC=spec.dd intro.dd lex.dd grammar.dd module.dd declaration.dd type.dd property.dd	\
 	attribute.dd pragma.dd expression.dd statement.dd arrays.dd			\
@@ -51,7 +51,7 @@ TARGETS=cpptod.html ctod.html pretod.html cppcontracts.html index.html overview.
 	memory-safe-d.html d-floating-point.html migrate-to-shared.html		\
 	D1toD2.html unittest.html hash-map.html intro-to-datetime.html		\
 	simd.html deprecate.html download.html 32-64-portability.html		\
-	d-array-article.html dll-linux.html bugstats.php.html
+	d-array-article.html dll-linux.html bugstats.php.html mobilenav.html
 
 
 CHMTARGETS=d.hhp d.hhc d.hhk d.chm
@@ -149,6 +149,8 @@ exception-safe.html : $(DDOC) exception-safe.dd
 expression.html : $(DDOC) expression.dd
 
 faq.html : $(DDOC) faq.dd
+
+mobilenav.html : $(DDOC) mobilenav.dd
 
 features2.html : $(DDOC) features2.dd
 


### PR DESCRIPTION
My comment here:
https://issues.dlang.org/show_bug.cgi?id=13997#c1

The sidebars make the content too narrow on a small screen, so this removes them. However, the sidebar serves a useful nav purpose, so I added a new file which you can see by clicking the logo on the small thing. idk if that's any good, but it seems better than nothing.

Also, I was not able to actually test these changes since I can't get the website to build on my box. Trying to do that wasted too much time and put me overbudget on this, I still have a lot to do tonight! But it isn't a complicated change, so I'm reasonably confident it will do what I want it to do.

whether that sucks or not is another question though.