### PR TITLE
Issue 13941 - NewExpression grammar is insufficient

### DIFF
--- a/declaration.dd
+++ b/declaration.dd
@@ -78,8 +78,7 @@ $(GNAME AltFuncDeclaratorSuffix):
 
 $(GRAMMAR
 $(GNAME Type):
-    $(GLINK TypeCtors)$(OPT) $(GLINK BasicType)
-    $(GLINK TypeCtors)$(OPT) $(GLINK BasicType) $(GLINK AltDeclarator)
+    $(GLINK TypeCtors)$(OPT) $(GLINK BasicType) $(GLINK BasicType2)$(OPT)
 
 $(GNAME TypeCtors):
     $(GLINK TypeCtor)
@@ -125,6 +124,9 @@ $(MULTICOLS 5,
     $(D void))
 
 $(GNAME BasicType2):
+    $(GLINK BasicType2X) $(GLINK BasicType2)$(OPT)
+
+$(GNAME BasicType2X):
     $(D *)
     $(D [ ])
     $(D [) $(VEXPRESSION) $(D ])

--- a/grammar.dd
+++ b/grammar.dd
@@ -10,8 +10,7 @@ $(H3 $(LNAME2 type, Type))
 
 $(GRAMMAR
 $(GNAME Type):
-    $(GLINK TypeCtors)$(OPT) $(GLINK BasicType)
-    $(GLINK TypeCtors)$(OPT) $(GLINK BasicType) $(GLINK AltDeclarator)
+    $(GLINK TypeCtors)$(OPT) $(GLINK BasicType) $(GLINK BasicType2)$(OPT)
 
 $(GNAME TypeCtors):
     $(GLINK TypeCtor)
@@ -57,6 +56,9 @@ $(GNAME BasicTypeX):
     $(D void)
 
 $(GNAME BasicType2):
+    $(GLINK BasicType2X) $(GLINK BasicType2)$(OPT)
+
+$(GNAME BasicType2X):
     $(D *)
     $(D [ ])
     $(D [) $(ASSIGNEXPRESSION) $(D ])


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13941

- Fix `Type` rule by using `BasicType2`
  It should be consistent with parseType() in dmd code.

- `BasicType2` should handle repetition
  It should be consistent with parseBasicType2() in dmd code.