### PR TITLE
Adjust padding and menu width to accomodate long names in library reference

### DIFF
--- a/css/cssmenu.css.dd
+++ b/css/cssmenu.css.dd
@@ -44,7 +44,7 @@ Ddoc
   border-radius: 3px 3px 0 0;
 }
 #cssmenu > ul > li:first-child > a {
-  padding: 15px 10px;
+  padding: 4px;
   background: url(../images/pattern.png) top left repeat;
   border: none;
   border-top: 1px solid $(top_border);
@@ -92,12 +92,10 @@ Ddoc
 }
 #cssmenu > ul > li > a > span {
   display: block;
-  padding: 12px 10px;
+  padding: 4px;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
-  padding-top: 4px;
-  padding-bottom: 4px;
 }
 #cssmenu > ul > li > a:hover {
   text-decoration: none;
@@ -137,24 +135,22 @@ body.have-javascript #cssmenu ul ul {
   border-bottom: none;
 }
 #cssmenu ul ul a {
-  padding: 10px 10px 10px 25px;
+  padding: 4px 4px 4px 12px;
   display: block;
   color: $(submenu_a);
   font-size: 12px;
   font-weight: normal;
-  padding-top: 4px;
-  padding-bottom: 4px;
 }
 #cssmenu ul ul a:before {
   content: "»";
   position: absolute;
-  left: 10px;
+  left: 4px;
   color: $(submenu_highlight);
 }
 #cssmenu ul ul li.active a:after {
   content: "►";
   position: absolute;
-  right: 10px;
+  right: 4px;
   color: $(submenu_highlight);
 }
 #cssmenu ul ul a:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -442,7 +442,7 @@ div#navigation
 {
 	font-size: 0.875em;
 	float: left;
-	width: 11.5em;
+	width: 14.5em;
 	padding: 0 1.5em;
 }
 
@@ -450,7 +450,7 @@ div#content
 {
     text-align: justify;
 	min-height: 440px;
-	margin-left: 13.5em;
+	margin-left: 16.6em;
 	padding: 1.6em;
 	padding-top: 1.3em;
 	padding-bottom: 1em;


### PR DESCRIPTION
This PR provides an alternative to PR #793.  It increases the menu width, and tries to make things a little more compact to accommodate long names in the library reference like `std.container.binaryheap`.  However, this and #793 are compatible and can be pulled together.

![wider_menus](https://cloud.githubusercontent.com/assets/6023641/5815063/679dac42-a0d5-11e4-9a3c-95a45d7ec3a3.png)
