### PR TITLE
Remove collapse of already-open menu.

### DIFF
--- a/js/cssmenu.js
+++ b/js/cssmenu.js
@@ -24,7 +24,7 @@ $('#cssmenu > ul > li > a').click(function() {
     checkElement.slideUp('normal');
   }
   if((checkElement.is('ul')) && (!checkElement.is(':visible'))) {
-    $('#cssmenu ul ul:visible').slideUp('normal');
+    /* $('#cssmenu ul ul:visible').slideUp('normal'); */
     checkElement.slideDown('normal');
   }
   if($(this).closest('li').find('ul').children().length == 0) {


### PR DESCRIPTION
When you expand one submenu and it collapses another, it can have particularly annoying results. For example, when in the standard library docs, and you want to expand multiple sections (std and core), you cannot. In addition, the following sequence is quite annoying:

1. expand std.
2. expand core.

So when you expand std, it has many entries, scrolling core off the screen. You must scroll down to reach the core menu. As soon as you open core, it collapses std. core has very few entries in it, so the overall size shrinks tremendously. This makes the menu suck itself up off the screen, and now you have to scroll up to get at the submenus.

This fix simply avoids collapsing the already-open menu.