### PR TITLE
Directly replace GLINK2 with GLINK in grammar page

### DIFF
--- a/grammar.dd
+++ b/grammar.dd
@@ -1810,3 +1810,4 @@ Macros:
         PSCURLYSCOPE=$(GLINK NonEmptyOrScopeBlockStatement)
         TRAITS_LINK2=$(LINK2 traits.html#$1, $(D $1))
         GLINK_LEX=$(GLINK2 lex, $1)
+        GLINK2=$(GLINK $2)


### PR DESCRIPTION
Currently some links in grammar page jump out from grammar page.

e.g. The `Type` under [EnumBaseType](http://dlang.org/grammar.html#EnumBaseType)

They should be internal links instead.