### PR TITLE
[Trivial] Remove useless macro

### DIFF
--- a/code_coverage.dd
+++ b/code_coverage.dd
@@ -228,5 +228,3 @@ Macros:
 	TITLE=Code Coverage Analysis
 	WIKI=Dcover
 	CATEGORY_DOWNLOAD=$0
-	RPAREN=)
-


### PR DESCRIPTION
It's hardwired into Ddoc.