### PR TITLE
allow scrolling of the mobile navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,7 @@ body
 	font-size: 100%;
 	font-family: Verdana, "Deja Vu", "Bitstream Vera Sans", sans-serif;
 	margin: 0px auto;
+	position: relative; /* So that absolute/fixed positions cling to this. */
 }
 
 a.btn
@@ -1059,7 +1060,7 @@ div#mobile-top, div#mobile-search {
 
 	div#navigation {
 		display: block;
-		position: fixed;
+		position: absolute;
 		top: 0;
 		left: -15em;
 		height: 100%;


### PR DESCRIPTION
With position:fixed lower elements would end up unreachable below the
screen on smaller screens.

body{position:relative} makes it so that #navigation and
#navigation-cancel extend all the way down to the bottom of &lt;body&gt;.