### PR TITLE
(follow-up to #819) mobile menu: make shadow and cancel area go all the way down, too

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1060,7 +1060,7 @@ div#mobile-top, div#mobile-search {
 		position: absolute;
 		top: 0;
 		left: -15em;
-		height: 100%;
+		min-height: 100%;
 		background-color: #1f252b;
 		padding: 0;
 		margin: 0;
@@ -1071,7 +1071,7 @@ div#mobile-top, div#mobile-search {
 	}
 
 	div#navigation-cancel {
-		position: absolute;
+		position: fixed;
 		left: 0; top: 0; right: 0; bottom: 0;
 		background-color: rgba(255,255,255,0.5);
 		z-index: 10000;


### PR DESCRIPTION
before: ![iconscreenshot1](https://cloud.githubusercontent.com/assets/9287500/5846945/5983c0d0-a1c8-11e4-8d48-d1c8c073a3fb.png) after: ![iconscreenshot1](https://cloud.githubusercontent.com/assets/9287500/5846946/5b527122-a1c8-11e4-8085-a5008a735f67.png)
