### PR TITLE
change media query units to em

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1058,7 +1058,7 @@ div#mobile-top, div#mobile-search {
 	display: none;
 }
 
-@media only screen and (max-width: 1024px) {
+@media only screen and (max-width: 64em) { /* 1024px for default font-size 16 */
 	
 	div#news{
 		display: none;
@@ -1070,7 +1070,7 @@ div#mobile-top, div#mobile-search {
 	
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 50em) { /* 800px for default font-size 16 */
 
 	/* Disable desktop-size UI elements */
 


### PR DESCRIPTION
This way, the layout is switched not only based on window size, but also
based on the set font-size. E.g. when a user has set the font-size to be
twice as large as usual, the 'mobile' layout will be used for window
widths up to 1600px.