### PR TITLE
px to em for #tool's position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -651,9 +651,10 @@ div#tools
 {
 	display: inline;
 	float: right;
-	margin: 0;
-	margin-top: -15px;
-	margin-right: -18px;
+	margin:
+		-1.1em /* = -(1.3em [#content's padding-top] - 0.2em) */
+		-1.4em /* = -(1.6em [#content's padding-right] - 0.2em) */
+		1em 1em;
 	text-align: right;
 }
 


### PR DESCRIPTION
Should be pretty much invisible. Avoids weirdness with extraordinary user-set font-sizes.