### PR TITLE
remove margin top from the home page heading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -162,7 +162,6 @@ h1, h2, h3, h4, h5, h6
 
 h1
 {
-	margin-top: 0;
 	font-size: 2.0em;
 }
 
@@ -538,6 +537,11 @@ div#content
 	-moz-border-radius: 5px;
 	-webkit-border-radius: 5px;
 	border-radius: 5px;
+}
+
+div#content *:first-child + * /* conceptually the first child, skipping #tools */
+{
+	margin-top: 0;
 }
 
 body.chm

--- a/index.dd
+++ b/index.dd
@@ -2,8 +2,7 @@ Ddoc
 
 $(D_S D Programming Language,
 
-$(SECTION3 The D programming language. Modern
-convenience. Modeling power. Native efficiency.,
+$(SECTION3 The D programming language. $(SPAN style="display: inline-block", Modern convenience. Modeling power. Native efficiency.),
 
 Conference websites, videos and slides:
 $(UL


### PR DESCRIPTION
It slipped through CSS, because it's not an &lt;h1&gt;.

Before/after:
![iconscreenshot1](https://cloud.githubusercontent.com/assets/9287500/5889091/766416d6-a417-11e4-90a6-865c21113e09.png)
