### PR TITLE
Redo #827: Remove first prefix from submenus in library reference

### DIFF
--- a/std_navbar-2.066.1.ddoc
+++ b/std_navbar-2.066.1.ddoc
@@ -1,6 +1,8 @@
-LIBITEM=$(A $1$(LIBITEM_RECURSE1 $+).html, $(D $1$(LIBITEM_RECURSE2 $+)))
+LIBITEM=$(A $1$(LIBITEM_RECURSE1 $+).html, $(D $2))
+LIBITEM2=$(A $1$(LIBITEM_RECURSE1 $+).html, $(D $(LIBITEM_RECURSE2 $+)))
 LIBITEM_RECURSE1=_$1$(LIBITEM_RECURSE1 $+)
-LIBITEM_RECURSE2=.&#x200B;$1$(LIBITEM_RECURSE2 $+)
+LIBITEM_RECURSE2=$1$(LIBITEM_RECURSE3 $+)
+LIBITEM_RECURSE3=.&#x200B;$1$(LIBITEM_RECURSE3 $+)
 _=
 
 NAVIGATION_PHOBOS=
@@ -19,21 +21,20 @@ $(DIVID cssmenu, $(UL
 		  $(LIBITEM std, compiler),
 		  $(LIBITEM std, complex),
 		  $(LIBITEM std, concurrency),
-		  $(LIBITEM std, container, package),
-		  $(LIBITEM std, container, array),
-		  $(LIBITEM std, container, binaryheap),
-		  $(LIBITEM std, container, dlist),
-		  $(LIBITEM std, container, rbtree),
-		  $(LIBITEM std, container, slist),
-		  $(LIBITEM std, container, util),
+		  $(LIBITEM2 std, container, package),
+		  $(LIBITEM2 std, container, array),
+		  $(LIBITEM2 std, container, binaryheap),
+		  $(LIBITEM2 std, container, dlist),
+		  $(LIBITEM2 std, container, rbtree),
+		  $(LIBITEM2 std, container, slist),
+		  $(LIBITEM2 std, container, util),
 		  $(LIBITEM std, conv),
-		  $(LIBITEM std, csv),
 		  $(LIBITEM std, datetime),
-		  $(LIBITEM std, digest, crc),
-		  $(LIBITEM std, digest, digest),
-		  $(LIBITEM std, digest, md),
-		  $(LIBITEM std, digest, ripemd),
-		  $(LIBITEM std, digest, sha),
+		  $(LIBITEM2 std, digest, crc),
+		  $(LIBITEM2 std, digest, digest),
+		  $(LIBITEM2 std, digest, md),
+		  $(LIBITEM2 std, digest, ripemd),
+		  $(LIBITEM2 std, digest, sha),
 		  $(LIBITEM std, encoding),
 		  $(LIBITEM std, exception),
 		  $(LIBITEM std, file),
@@ -44,8 +45,8 @@ $(DIVID cssmenu, $(UL
 		  $(LIBITEM std, math),
 		  $(LIBITEM std, mathspecial),
 		  $(LIBITEM std, mmfile),
-		  $(LIBITEM std, net, curl),
-		  $(LIBITEM std, net, isemail),
+		  $(LIBITEM2 std, net, curl),
+		  $(LIBITEM2 std, net, isemail),
 		  $(LIBITEM std, numeric),
 		  $(LIBITEM std, outbuffer),
 		  $(LIBITEM std, parallelism),
@@ -70,16 +71,16 @@ $(DIVID cssmenu, $(UL
 		  $(LIBITEM std, utf),
 		  $(LIBITEM std, uuid),
 		  $(LIBITEM std, variant),
-		  $(LIBITEM std, windows, charset),
+		  $(LIBITEM2 std, windows, charset),
 		  $(LIBITEM std, xml),
 		  $(LIBITEM std, zip),
 		  $(LIBITEM std, zlib)
 	  )
 	$(MENU_W_SUBMENU $(TT etc))
 	  $(ITEMIZE
-	    $(LIBITEM etc, c, curl),
-	    $(LIBITEM etc, c, sqlite3),
-	    $(LIBITEM etc, c, zlib)
+	    $(LIBITEM2 etc, c, curl),
+	    $(LIBITEM2 etc, c, sqlite3),
+	    $(LIBITEM2 etc, c, zlib)
 	  )
 	$(MENU_W_SUBMENU $(TT core))
 	  $(ITEMIZE
@@ -94,13 +95,13 @@ $(DIVID cssmenu, $(UL
 		$(LIBITEM core, thread),
 		$(LIBITEM core, time),
 		$(LIBITEM core, vararg),
-		$(LIBITEM core, sync, barrier),
-		$(LIBITEM core, sync, condition),
-		$(LIBITEM core, sync, config),
-		$(LIBITEM core, sync, exception),
-		$(LIBITEM core, sync, mutex),
-		$(LIBITEM core, sync, rwmutex),
-		$(LIBITEM core, sync, semaphore)
+		$(LIBITEM2 core, sync, barrier),
+		$(LIBITEM2 core, sync, condition),
+		$(LIBITEM2 core, sync, config),
+		$(LIBITEM2 core, sync, exception),
+		$(LIBITEM2 core, sync, mutex),
+		$(LIBITEM2 core, sync, rwmutex),
+		$(LIBITEM2 core, sync, semaphore)
 	  )
 	$(MENU http://code.dlang.org, 3rd Party Packages)
 ))

--- a/std_navbar-prerelease.ddoc
+++ b/std_navbar-prerelease.ddoc
@@ -1,6 +1,8 @@
-LIBITEM=$(A $1$(LIBITEM_RECURSE1 $+).html, $(D $1$(LIBITEM_RECURSE2 $+)))
+LIBITEM=$(A $1$(LIBITEM_RECURSE1 $+).html, $(D $2))
+LIBITEM2=$(A $1$(LIBITEM_RECURSE1 $+).html, $(D $(LIBITEM_RECURSE2 $+)))
 LIBITEM_RECURSE1=_$1$(LIBITEM_RECURSE1 $+)
-LIBITEM_RECURSE2=.&#x200B;$1$(LIBITEM_RECURSE2 $+)
+LIBITEM_RECURSE2=$1$(LIBITEM_RECURSE3 $+)
+LIBITEM_RECURSE3=.&#x200B;$1$(LIBITEM_RECURSE3 $+)
 _=
 
 NAVIGATION_PHOBOS=
@@ -10,13 +12,7 @@ $(DIVID cssmenu, $(UL
 	$(MENU object.html, $(TT object))
 	$(MENU_W_SUBMENU $(TT std))
 	  $(ITEMIZE
-		  $(LIBITEM std, algorithm, package),
-		  $(LIBITEM std, algorithm, comparison),
-		  $(LIBITEM std, algorithm, iteration),
-		  $(LIBITEM std, algorithm, mutation),
-		  $(LIBITEM std, algorithm, searching),
-		  $(LIBITEM std, algorithm, setops),
-		  $(LIBITEM std, algorithm, sorting),
+		  $(LIBITEM std, algorithm),
 		  $(LIBITEM std, array),
 		  $(LIBITEM std, ascii),
 		  $(LIBITEM std, base64),
@@ -25,21 +21,20 @@ $(DIVID cssmenu, $(UL
 		  $(LIBITEM std, compiler),
 		  $(LIBITEM std, complex),
 		  $(LIBITEM std, concurrency),
-		  $(LIBITEM std, container, package),
-		  $(LIBITEM std, container, array),
-		  $(LIBITEM std, container, binaryheap),
-		  $(LIBITEM std, container, dlist),
-		  $(LIBITEM std, container, rbtree),
-		  $(LIBITEM std, container, slist),
-		  $(LIBITEM std, container, util),
+		  $(LIBITEM2 std, container, package),
+		  $(LIBITEM2 std, container, array),
+		  $(LIBITEM2 std, container, binaryheap),
+		  $(LIBITEM2 std, container, dlist),
+		  $(LIBITEM2 std, container, rbtree),
+		  $(LIBITEM2 std, container, slist),
+		  $(LIBITEM2 std, container, util),
 		  $(LIBITEM std, conv),
-		  $(LIBITEM std, csv),
 		  $(LIBITEM std, datetime),
-		  $(LIBITEM std, digest, crc),
-		  $(LIBITEM std, digest, digest),
-		  $(LIBITEM std, digest, md),
-		  $(LIBITEM std, digest, ripemd),
-		  $(LIBITEM std, digest, sha),
+		  $(LIBITEM2 std, digest, crc),
+		  $(LIBITEM2 std, digest, digest),
+		  $(LIBITEM2 std, digest, md),
+		  $(LIBITEM2 std, digest, ripemd),
+		  $(LIBITEM2 std, digest, sha),
 		  $(LIBITEM std, encoding),
 		  $(LIBITEM std, exception),
 		  $(LIBITEM std, file),
@@ -50,18 +45,18 @@ $(DIVID cssmenu, $(UL
 		  $(LIBITEM std, math),
 		  $(LIBITEM std, mathspecial),
 		  $(LIBITEM std, mmfile),
-		  $(LIBITEM std, net, curl),
-		  $(LIBITEM std, net, isemail),
+		  $(LIBITEM2 std, net, curl),
+		  $(LIBITEM2 std, net, isemail),
 		  $(LIBITEM std, numeric),
 		  $(LIBITEM std, outbuffer),
 		  $(LIBITEM std, parallelism),
 		  $(LIBITEM std, path),
 		  $(LIBITEM std, process),
 		  $(LIBITEM std, random),
-		  $(LIBITEM std, range, package),
-		  $(LIBITEM std, range, interfaces),
-		  $(LIBITEM std, range, primitives),
-		  $(LIBITEM std, regex, package),
+		  $(LIBITEM2 std, range, package),
+		  $(LIBITEM2 std, range, interfaces),
+		  $(LIBITEM2 std, range, primitives),
+		  $(LIBITEM2 std, regex, package),
 		  $(LIBITEM std, signals),
 		  $(LIBITEM std, socket),
 		  $(LIBITEM std, socketstream),
@@ -78,16 +73,16 @@ $(DIVID cssmenu, $(UL
 		  $(LIBITEM std, utf),
 		  $(LIBITEM std, uuid),
 		  $(LIBITEM std, variant),
-		  $(LIBITEM std, windows, charset),
+		  $(LIBITEM2 std, windows, charset),
 		  $(LIBITEM std, xml),
 		  $(LIBITEM std, zip),
 		  $(LIBITEM std, zlib)
 	  )
 	$(MENU_W_SUBMENU $(TT etc))
 	  $(ITEMIZE
-	    $(LIBITEM etc, c, curl),
-	    $(LIBITEM etc, c, sqlite3),
-	    $(LIBITEM etc, c, zlib)
+	    $(LIBITEM2 etc, c, curl),
+	    $(LIBITEM2 etc, c, sqlite3),
+	    $(LIBITEM2 etc, c, zlib)
 	  )
 	$(MENU_W_SUBMENU $(TT core))
 	  $(ITEMIZE
@@ -102,13 +97,13 @@ $(DIVID cssmenu, $(UL
 		$(LIBITEM core, thread),
 		$(LIBITEM core, time),
 		$(LIBITEM core, vararg),
-		$(LIBITEM core, sync, barrier),
-		$(LIBITEM core, sync, condition),
-		$(LIBITEM core, sync, config),
-		$(LIBITEM core, sync, exception),
-		$(LIBITEM core, sync, mutex),
-		$(LIBITEM core, sync, rwmutex),
-		$(LIBITEM core, sync, semaphore)
+		$(LIBITEM2 core, sync, barrier),
+		$(LIBITEM2 core, sync, condition),
+		$(LIBITEM2 core, sync, config),
+		$(LIBITEM2 core, sync, exception),
+		$(LIBITEM2 core, sync, mutex),
+		$(LIBITEM2 core, sync, rwmutex),
+		$(LIBITEM2 core, sync, semaphore)
 	  )
 	$(MENU http://code.dlang.org, 3rd Party Packages)
 ))


### PR DESCRIPTION
Had trouble rebasing.  This is a redo of #827.