### PR TITLE
un-underline jump links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -933,6 +933,14 @@ td.compYes  /* comparison with D: "YES" */
 	background-color: #E4E9EF;
 }
 
+.quickindex a {
+	text-decoration: none;
+}
+
+.quickindex a:hover {
+	text-decoration: underline;
+}
+
 .question
 {
     display: inline;


### PR DESCRIPTION
Before/after:

![iconscreenshot1](https://cloud.githubusercontent.com/assets/9287500/5892737/edb07d26-a4c9-11e4-8a0d-6e97fff94e90.png)

As @CyberShadow said in #831, it's somewhat "inconsistent to do it selectively in the main content". So I'm not sure about this.

Phobos modules with manually maintained jump link tables will need to add a class to be affected by this. PR is on the way.