### PR TITLE
Add std.algorithm submodules to navbar.

### DIFF
--- a/std_navbar-prerelease.ddoc
+++ b/std_navbar-prerelease.ddoc
@@ -5,7 +5,15 @@ $(DIVID cssmenu, $(UL
 	$(MENU object.html, $(TT object))
 	$(MENU_W_SUBMENU $(TT std))
 	  $(ITEMIZE
-		  $(MODULE2 std, algorithm),
+		  $(MODULE2 std, algorithm, package),
+		  $(PACKAGE
+			$(MODULE3 std, algorithm, comparison),
+			$(MODULE3 std, algorithm, iteration),
+			$(MODULE3 std, algorithm, mutation),
+			$(MODULE3 std, algorithm, searching),
+			$(MODULE3 std, algorithm, setops),
+			$(MODULE3 std, algorithm, sorting),
+		  ),
 		  $(MODULE2 std, array),
 		  $(MODULE2 std, ascii),
 		  $(MODULE2 std, base64),


### PR DESCRIPTION
Apparently one of the recent PR's accidentally overwrote the new std.algorithm submodules in phobos-prerelease's navbar. Note that this PR only affects phobos-prerelease, the current release still has the original unsplit std.algorithm without submodules.