### PR TITLE
Clarify scope of application of invariants

### DIFF
--- a/class.dd
+++ b/class.dd
@@ -778,8 +778,10 @@ $(GNAME Invariant):
 )
 
     Class invariants are used to specify characteristics of a class that always
-    must be true (except while executing a member function).
-    They are described in $(GLINK2 dbc, Invariants).
+    must be true (except while executing a member function). However, it only
+    applies to object internal consistency. Using invariant to check for global
+    program state can lead to subtle issues and is generally not recommended.
+    Invariants are described in more details in $(GLINK2 dbc, Invariants).
 
 $(H3 $(LNAME2 allocators, Class Allocators))
 $(B Note): Class allocators are deprecated in D2.

--- a/dbc.dd
+++ b/dbc.dd
@@ -181,6 +181,13 @@ class Date
 	$(LI postconditions)
 	)
 
+    $(P Because at the start of class/struct destructor object instance may
+    point to other object instances already collected by the GC trying to
+    check theirs state can lead to undefined behaviour. Invariants are
+    designed to ensure internal correctness of the object and shouldn't check
+    the global state or state of other GC objects (former can be done with
+    a lot of care but generally is discouraged).)
+
 	$(P The code in the invariant may not call any public non-static members
 	of the class or struct, either directly or indirectly.
 	Doing so will result in a stack overflow, as the invariant will wind


### PR DESCRIPTION
Specifically, explain why it is not OK to refer to
other GC managed objects from invariant.