### PR TITLE
menu: cast text shadows down, not up

### DIFF
--- a/css/cssmenu.css.dd
+++ b/css/cssmenu.css.dd
@@ -47,7 +47,7 @@ Ddoc
   text-align: center;
   font-size: 18px;
   font-weight: 300;
-  text-shadow: 0 -1px 1px $(menu_first_shadow);
+  text-shadow: 0 1px 1px $(menu_first_shadow);
 }
 #cssmenu > ul > li:first-child > a > span {
   padding: 0;
@@ -66,7 +66,7 @@ Ddoc
   display: block;
   background: url(../images/pattern.png) top left repeat;
   color: $(menu_a);
-  text-shadow: 0 -1px 1px $(menu_a_shadow);
+  text-shadow: 0 1px 1px $(menu_a_shadow);
   -moz-transition: background 0.4s;
   -webkit-transition: background 0.4s;
   transition: background 0.4s;


### PR DESCRIPTION
Split off from #812.

Before/after:
![iconscreenshot1](https://cloud.githubusercontent.com/assets/9287500/5908112/e219e606-a5a4-11e4-8a12-a46325e64821.png)
