### PR TITLE
Supplemental fix for issue 13308

### DIFF
--- a/grammar.dd
+++ b/grammar.dd
@@ -963,7 +963,9 @@ $(GNAME AsmPrimaryExp):
     $(D __LOCAL_SIZE)
     $(D $)
     $(GLINK Register)
+    $(GLINK Register) $(D :) $(I AsmExp)
     $(GLINK Register64)
+    $(GLINK Register64) $(D :) $(I AsmExp)
     $(I DotIdentifier)
     $(D this)
 


### PR DESCRIPTION
This change synchronizes the AamPrimaryExp grammar between grammar.dd and iasm.dd.