### PR TITLE
Issue 13327 - Clarify manifest constant grammar

### DIFF
--- a/enum.dd
+++ b/enum.dd
@@ -36,7 +36,7 @@ $(GNAME AnonymousEnumMembers):
 
 $(GNAME AnonymousEnumMember):
     $(GLINK EnumMember)
-    $(GLINK2 declaration Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
+    $(GLINK2 declaration, Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
 )
 
 	$(P Enum declarations are used to define a group of constants.
@@ -242,7 +242,7 @@ enum
 $(H2 Manifest Constants)
 
 	$(P If there is only one member of an anonymous enum, the { } can
-	be omitted:
+	be omitted. Gramatically speaking, this is an $(GLINK2 declaration, AutoDeclaration).
 	)
 
 ---
@@ -266,4 +266,5 @@ enum size = __traits(classInstanceSize, Foo);  // evaluated at compile-time
 Macros:
 	TITLE=Enums
 	WIKI=Enum
+	CATEGORY_SPEC=$0
 

--- a/enum.dd
+++ b/enum.dd
@@ -6,7 +6,7 @@ $(GRAMMAR
 $(GNAME EnumDeclaration):
     $(D enum) $(I Identifier) $(GLINK EnumBody)
     $(D enum) $(I Identifier) $(D :) $(GLINK EnumBaseType) $(GLINK EnumBody)
-    $(AnonymousEnumDeclaration)
+    $(GLINK AnonymousEnumDeclaration)
 
 $(GNAME EnumBaseType):
     $(GLINK2 declaration, Type)

--- a/grammar.dd
+++ b/grammar.dd
@@ -1386,7 +1386,7 @@ $(GRAMMAR
 $(GNAME EnumDeclaration):
     $(D enum) $(I Identifier) $(GLINK EnumBody)
     $(D enum) $(I Identifier) $(D :) $(GLINK EnumBaseType) $(GLINK EnumBody)
-    $(AnonymousEnumDeclaration)
+    $(GLINK AnonymousEnumDeclaration)
 
 $(GNAME EnumBaseType):
     $(GLINK2 declaration, Type)

--- a/grammar.dd
+++ b/grammar.dd
@@ -1416,7 +1416,7 @@ $(GNAME AnonymousEnumMembers):
 
 $(GNAME AnonymousEnumMember):
     $(GLINK EnumMember)
-    $(GLINK2 declaration Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
+    $(GLINK2 declaration, Type) $(I Identifier) $(D =) $(ASSIGNEXPRESSION)
 )
 
 $(H3 $(LNAME2 template, Template))


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13327

This also fixes a DDOC macro usage issue introduced by https://github.com/D-Programming-Language/dlang.org/pull/775/