### PR TITLE
navbar for std.experimental.logger

### DIFF
--- a/css/cssmenu.css.dd
+++ b/css/cssmenu.css.dd
@@ -148,12 +148,6 @@ body.have-javascript #cssmenu ul ul ul {
 #cssmenu ul ul ul {
   border: 0;
 }
-#cssmenu ul ul ul a {
-  padding-left: 40px;
-}
-#cssmenu ul ul ul a:before {
-  left: 25px;
-}
 #cssmenu ul ul li.active > a:after {
   content: "►";
   position: absolute;
@@ -162,6 +156,20 @@ body.have-javascript #cssmenu ul ul ul {
 }
 #cssmenu ul ul a:hover {
   color: $(submenu_highlight);
+}
+
+#cssmenu ul ul ul a {
+  padding-left: 40px;
+}
+#cssmenu ul ul ul a:before {
+  left: 25px;
+}
+
+#cssmenu ul ul ul ul a {
+  padding-left: 55px;
+}
+#cssmenu ul ul ul ul a:before {
+  left: 40px;
 }
 
 Macros:

--- a/std.ddoc
+++ b/std.ddoc
@@ -23,6 +23,7 @@ _=
 MODULE=<a href="$2$(JOIN_LINE_TAIL $+).html" title="$2$(JOIN_DOT_TAIL $+)">$(D $1)</a>
 MODULE2=$(MODULE $2, $1, $+)
 MODULE3=$(MODULE $3, $1, $+)
+MODULE4=$(MODULE $4, $1, $+)
 PACKAGE=$(ITEMIZE $1,$+)
 PACKAGE_NAME=$(T h7,$(D $1))
 JOIN_LINE_TAIL=$(JOIN_LINE $+)

--- a/std_navbar-prerelease.ddoc
+++ b/std_navbar-prerelease.ddoc
@@ -43,6 +43,15 @@ $(DIVID cssmenu, $(UL
 		  ),
 		  $(MODULE2 std, encoding),
 		  $(MODULE2 std, exception),
+		  $(PACKAGE $(PACKAGE_NAME experimental),
+			$(MODULE3 std, experimental, logger, package),
+			$(PACKAGE
+			  $(MODULE4 std, experimental, logger, core),
+			  $(MODULE4 std, experimental, logger, filelogger),
+			  $(MODULE4 std, experimental, logger, multilogger),
+			  $(MODULE4 std, experimental, logger, nulllogger)
+			),
+		  ),
 		  $(MODULE2 std, file),
 		  $(MODULE2 std, format),
 		  $(MODULE2 std, functional),


### PR DESCRIPTION
Introduces CSS support for level 4 nesting (sigh).

Supersedes #864.