### PR TITLE
#d_lang -> #dlang

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -60,7 +60,7 @@ $(DIVID cssmenu, $(UL
         http://github.com/D-Programming-Language, D on GitHub,
         http://wiki.dlang.org, Wiki,
         http://wiki.dlang.org/Review_Queue, Review Queue,
-        http://twitter.com/search?q=%23d_lang, Twitter,
+        http://twitter.com/search?q=%23dlang, Twitter,
         http://digitalmars.com/d/dlinks.html, More Links
       )
     $(MENU_W_SUBMENU Books $(AMP) Articles)

--- a/index.dd
+++ b/index.dd
@@ -263,7 +263,7 @@ lists.puremagic.com/cgi-bin/mailman/listinfo/digitalmars-d-announce,
 [mailing list])). On Twitter, subscribe to D's official announcements
 channel, $(HTTP twitter.com/#!/D_Programming,@D_Programming), and
 search for (and disseminate) news using tag $(HTTP
-twitter.com/#!/search/%23d_lang, #d_lang).)
+twitter.com/#!/search/%23dlang, #dlang).)
 
 $(P Learning D and have a question about the best way to do X? The $(D
 digitalmars.D.learn) forum $(TAG2 span, style="font-size:80%", $(HTTP


### PR DESCRIPTION
It's the current standard.

http://forum.dlang.org/thread/ju9uin$1g5n$1@digitalmars.com