### PR TITLE
Remove redundant separate "std.experimental" menu

### DIFF
--- a/std_navbar-prerelease.ddoc
+++ b/std_navbar-prerelease.ddoc
@@ -130,16 +130,6 @@ $(DIVID cssmenu, $(UL
 		  $(MODULE3 core, sync, semaphore)
 		)
 	  )
-	$(MENU_W_SUBMENU $(TT std.experimental))
-	  $(ITEMIZE
-		$(MODULE3 std, experimental, logger, package),
-		$(PACKAGE
-		  $(MODULE4 std, experimental, logger, core),
-		  $(MODULE4 std, experimental, logger, filelogger),
-		  $(MODULE4 std, experimental, logger, multilogger),
-		  $(MODULE4 std, experimental, logger, nulllogger)
-		),
-	  )
 	$(MENU http://code.dlang.org, 3rd Party Packages)
 ))
 _=


### PR DESCRIPTION
Reverts D-Programming-Language/dlang.org#866

#866 and #865 are mutually redundant, and #865 sounds like a better idea.