### PR TITLE
Add note to install 'libevent.a' on OSX 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Make sure you have these prerequisites working:
 * The C++ compiler for your platform (invokable as `gcc`)
 * Optional: `latex` for building the pdf documentation
 * Optional: `kindlegen` for building the Kindle documentation
+* If you're running OSX, make sure you have some version of `libevent` installed
 
 ## Getting the code
 

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -80,7 +80,7 @@ $(DIVID cssmenu, $(UL
       )
     $(MENU_W_SUBMENU Resources)
       $(SUBMENU
-        library/index.html, $(NBSP)NEW Library Reference Preview,
+        library/index.html, NEW Library Reference Preview,
         bugstats.php, Bug Tracker,
         $(VISUALD), Visual D,
         dstyle.html, The D Style,


### PR DESCRIPTION
I needed to do it to build apidocs-... maybe others will need it too.