### PR TITLE
Mention function chaining as a benefit of UFCS

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -2206,9 +2206,19 @@ $(H3 $(LNAME2 pseudo-member, Uniform Function Call Syntax (UFCS)))
         // it's automatically rewritten to 'func(obj)'
         ---
 
-	$(P This provides a way to add functions to a class
-	externally as if they were public final member functions.
+	$(P This provides a way to add functions to a class externally as if they were
+	public final member functions, which enables
+	$(WEB www.drdobbs.com/architecture-and-design/component-programming-in-d/240008321,
+	function chaining and component programming).
 	)
+
+        ---
+        stdin.byLine(KeepTerminator.yes)
+            .map!(a => a.idup)
+            .array
+            .sort
+            .copy(stdout.lockingTextWriter());
+        ---
 
         $(P It also works with $(D @property) functions:)
 


### PR DESCRIPTION
The recent blog post on D as a native python had [a comment saying that they didn't initially get that UFCS enabled function chaining and pipeline programming](http://bitbashing.io/2015/01/26/d-is-like-native-python.html#comment-1818018598).  I've seen this mentioned a handful of times, would be good to explain it a bit in the docs, as it's [a feature that gets people excited](http://www.kr41.net/2013/08/27/uniform_function_call_syntax_in_d.html).

Also, would be good to start moving Walter's Dr. Dobb's articles to dlang.org, as that article's webpage started reloading repeatedly in my browser for some reason.