### PR TITLE
don't style ALOCAL as permalink to self

### DIFF
--- a/html.ddoc
+++ b/html.ddoc
@@ -7,7 +7,7 @@ A = <a href="$1">$+</a>
 ADEF = <a name="$0"></a>
 AHTTP = <a href="http://$1">$+</a>
 AHTTPS = <a class="https" href="https://$1">$+</a>
-ALOCAL = <a class="anchor" title="Permalink" href="#$1">$+</a>
+ALOCAL = <a href="#$1">$+</a>
 BIG = $(EMC big, $0)
 BR = <br>
 CAPTION = $(T caption, $0)


### PR DESCRIPTION
The styling was introduced in #776. I don't know if it was supposed to fix anything or if it's just been a mistake. Anyway, it hit a lot of links that really shouldn't be styled that way.

Exemplary before/after shot of grammar.html:
![iconscreenshot1](https://cloud.githubusercontent.com/assets/9287500/5993601/856a8a08-aa56-11e4-883a-da38d4d0dffe.png)
