### PR TITLE
increase max-widths

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1137,7 +1137,7 @@ div#mobile-top, div#mobile-search, div#mobile-hamburger
 	display: none;
 }
 
-@media only screen and (max-width: 64em) { /* 1024px for default font-size 16 */
+@media only screen and (max-width: 69.5em) { /* 1112px for default font-size 16 */
 	
 	div#news{
 		display: none;
@@ -1149,7 +1149,7 @@ div#mobile-top, div#mobile-search, div#mobile-hamburger
 	
 }
 
-@media only screen and (max-width: 50em) { /* 800px for default font-size 16 */
+@media only screen and (max-width: 54.5em) { /* 872px for default font-size 16 */
 
 	/* Disable desktop-size UI elements */
 


### PR DESCRIPTION
'The big grey bar' made the menu and the inter-column spacing wider, and
I'd forgotten to update these.

Both get 4.5em more for margin-left: 18em now, 13.5em before.

Hiding #news gets an additional 1em for margin-right: 21em now, 20em
before.