### PR TITLE
PDF fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,13 @@ chm
 *.exe
 *.obj
 
+# PDF
 dlangspec.d
+dlangspec-consolidated.d
+dlangspec.aux
+dlangspec.log
+dlangspec.out
+dlangspec.tex
 
 /web
 /2.*.ddoc

--- a/latex.ddoc
+++ b/latex.ddoc
@@ -383,7 +383,7 @@ DDOC=% Copyright (c) 1999-$(YEAR) by Digital Mars
 \usepackage{longtable}
 \usepackage[T1]{fontenc}
 
-\premulticols=1pt
+\premulticols=50pt
 \multicolsep=0pt
 
 \hypersetup{pdftitle={D Programming Language Specification}}


### PR DESCRIPTION
This fixes the following multicols error:

```
! Package multicol Error: Error saving partial page.

See the multicol package documentation for explanation.
Type  H <return>  for immediate help.
 ...

l.4182 \begin{multicols}{5}
                               \textit{LinkageAttribute}
? H
The part of the page before the multicols environment was nearly full with
the result that starting the environment will produce an overfull page. Some
text may be lost! Please increase \premulticols either generally or for this
environment by specifying a suitable value in the second optional argument to
the multicols environment.
```

I have no idea if this is the right way to fix it - I just set `\premulticols` to what I think is its default value.