### PR TITLE
Add IRC link to Community menu

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -58,6 +58,7 @@ $(DIVID cssmenu, $(UL
     $(MENU_W_SUBMENU Community)
       $(SUBMENU
         http://forum.dlang.org, Forums,
+        irc://irc.freenode.net/d, IRC,
         http://github.com/D-Programming-Language, D on GitHub,
         http://wiki.dlang.org, Wiki,
         http://wiki.dlang.org/Review_Queue, Review Queue,


### PR DESCRIPTION
Assuming someone's around, IRC is a nice medium for a quick Q&A, so I think it's worth featuring it on the website.