### PR TITLE
Move font selection for links to css

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,7 +52,7 @@ em.big
 em.tt
 {
     font-style: normal;
-    font-family: monospace;
+    font-family: Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace;
 }
 
 /* replaces <u> tag */

--- a/std.ddoc
+++ b/std.ddoc
@@ -18,7 +18,7 @@ TABLE = <table cellspacing=0 cellpadding=5><caption>$1</caption>$2</table>
 TD = <td>$0</td>
 TDNW = <td class="donthyphenate" nowrap>$0</td>
 SUB_IS_DEPRECATED=kept for compatibility, but collides with SUB=&sub; use SUBSCRIPT instead (this is a comment and can be changed into one if ddoc files ever start supporting comments)
-MYREF = <font face='Consolas, "Bitstream Vera Sans Mono", "Andale Mono", Monaco, "DejaVu Sans Mono", "Lucida Console", monospace'><a href="#.$1">$1</a>&nbsp;</font>
+MYREF = <a href="#.$1">$(TT $1)</a>&nbsp;
 _=
 
 MODULE=<a href="$2$(JOIN_LINE_TAIL $+).html" title="$2$(JOIN_DOT_TAIL $+)">$(D $1)</a>


### PR DESCRIPTION
This addresses the odd small fonts for the function names in http://dlang.org/phobos-prerelease/std_algorithm_package.html.