### PR TITLE
update style rules for deeply nested packages

### DIFF
--- a/css/cssmenu.css.dd
+++ b/css/cssmenu.css.dd
@@ -144,18 +144,31 @@ body.have-javascript #cssmenu ul ul ul {
   color: $(submenu_highlight);
 }
 
-#cssmenu ul ul ul a {
+#cssmenu ul ul ul a,
+#cssmenu ul ul ul h7 {
   padding-left: 40px;
 }
-#cssmenu ul ul ul a:before {
+#cssmenu ul ul ul a:before,
+#cssmenu ul ul ul h7:before {
   left: 25px;
 }
 
-#cssmenu ul ul ul ul a {
+#cssmenu ul ul ul ul a,
+#cssmenu ul ul ul ul h7 {
   padding-left: 55px;
 }
-#cssmenu ul ul ul ul a:before {
+#cssmenu ul ul ul ul a:before,
+#cssmenu ul ul ul ul h7:before {
   left: 40px;
+}
+
+#cssmenu ul ul ul ul ul a,
+#cssmenu ul ul ul ul ul h7 {
+  padding-left: 70px;
+}
+#cssmenu ul ul ul ul ul a:before,
+#cssmenu ul ul ul ul ul h7:before {
+  left: 55px;
 }
 
 Macros:

--- a/std.ddoc
+++ b/std.ddoc
@@ -25,6 +25,7 @@ MODULE=<a href="$2$(JOIN_LINE_TAIL $+).html" title="$2$(JOIN_DOT_TAIL $+)">$(D $
 MODULE2=$(MODULE $2, $1, $+)
 MODULE3=$(MODULE $3, $1, $+)
 MODULE4=$(MODULE $4, $1, $+)
+MODULE5=$(MODULE $5, $1, $+)
 PACKAGE=$1</li><li>$(ITEMIZE $+)
 PACKAGE_NAME=$(T h7,$(D $1))
 JOIN_LINE_TAIL=$(JOIN_LINE $+)


### PR DESCRIPTION
- missing styles for nested packages without package.d
- added MODULE5 styles for core.sys.posix.sys.*