### PR TITLE
Fix PHOBOS macro

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -229,7 +229,7 @@ _=
 PC=$(TC p, $1, $+)
 _=
 
-PHOBOS=$(SPANC phobos, $(AHTTP dlang.org/phobos/std_$1.html#$2, $(TAIL $3)))
+PHOBOS=$(SPANC phobos, $(AHTTP dlang.org/phobos/std_$1.html#$2, $(TAIL $+)))
 PHOBOSSRC=$(SPANC phobos_src, $(AHTTPS github.com/D-Programming-Language/phobos/blob/master/$0, $0))
 _=
 


### PR DESCRIPTION
This PR fixes link text generation, e.g. the 2nd paragraph of http://dlang.org/arrays.html#strings-unicode.