### PR TITLE
Issue 14258 - SIGSEGV in dpldocs

### DIFF
--- a/dpl-docs/dub.json
+++ b/dpl-docs/dub.json
@@ -1,7 +1,7 @@
 {
 	"name": "dpl-docs",
 	"dependencies": {
-		"ddox": "~>0.9.21"
+		"ddox": "~>0.10.2"
 	},
 	"versions": ["VibeCustomMain"]
 }

--- a/dpl-docs/dub.selections.json
+++ b/dpl-docs/dub.selections.json
@@ -1,10 +1,13 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"ddox": "0.10.0",
-		"vibe-d": "0.7.21",
+		"libdparse": "0.1.1",
+		"memutils": "~master",
+		"ddox": "0.10.2",
+		"vibe-d": "0.7.23-beta.1+commit.2.gb9b89bf",
 		"libevent": "2.0.1+2.0.16",
-		"openssl": "1.0.0+1.0.0e",
-		"libev": "4.0.0+4.04"
+		"openssl": "1.1.4+1.0.1g",
+		"libev": "5.0.0+4.04",
+		"libasync": "0.7.0"
 	}
 }


### PR DESCRIPTION
This pull upgrades to the latest version of DDOX, which fixes the crash. The root cause was a missing termination condition for recursive macro instantiations.