### PR TITLE
mostly fix Issue 14280 - Links to command line tools have disappeared fr...

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -66,27 +66,54 @@ $(DIVID cssmenu, $(UL
         http://twitter.com/search?q=%23dlang, Twitter,
         http://digitalmars.com/d/dlinks.html, More Links
       )
+    $(MENU_W_SUBMENU Compilers $(AMP) Tools)
+      $(SUBMENU
+        dmd-windows.html, dmd $(NDASH) reference compiler,
+        http://gdcproject.org, gdc $(NDASH) gcc-based compiler,
+        http://wiki.dlang.org/LDC, ldc $(NDASH) LLVM-based compiler,
+        rdmd.html, rdmd $(NDASH) pseudo interpreter,
+        windbg.html, windbg $(NDASH) debugger,
+        htod.html, htod $(NDASH) .h to .d
+      )
     $(MENU_W_SUBMENU Books $(AMP) Articles)
       $(SUBMENU
         http://ddili.org/ders/d.en/index.html, Online Book (free),
         http://wiki.dlang.org/Books, More Books,
         howtos.html, How-tos,
         faq.html, FAQ,
+        const-faq.html, const(FAQ),
         comparison.html, Feature Overview,
         d-floating-point.html, Floating Point,
         wc.html, Example: wc,
         warnings.html, Warnings,
+        rationale.html, Rationale,
         builtin.html, Builtin Rationale,
         ctod.html, C to D,
         cpptod.html, C++ to D,
-        pretod.html, C Preprocessor vs D
+        pretod.html, C Preprocessor vs D,
+        code_coverage.html, Code coverage analysis,
+        exception-safe.html, Exception Safety,
+        hijack.html, Hijacking,
+        intro-to-datetime.html, Introduction to std.datetime,
+        lazy-evaluation.html, Lazy Evaluation,
+        migrate-to-shared.html, Migrating to Shared,
+        mixin.html, Mixins,
+        regular-expression.html, Regular Expressions,
+        safed.html, SafeD,
+        templates-revisited.html, Templates Revisited,
+        tuple.html, Tuples,
+        variadic-function-templates.html, Variadic Templates,
+        d-array-article.html, D Slices
       )
     $(MENU_W_SUBMENU Resources)
       $(SUBMENU
         library/index.html, NEW Library Reference Preview,
         bugstats.php, Bug Tracker,
         $(VISUALD), Visual D,
+        http://wiki.dlang.org/Editors, Editors,
+        http://wiki.dlang.org/IDEs, IDEs,
         dstyle.html, The D Style,
+        glossary.html, Glossary,
         acknowledgements.html, Acknowledgments,
         sitemap.html, Sitemap
       )

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -72,7 +72,6 @@ $(DIVID cssmenu, $(UL
         http://gdcproject.org, gdc $(NDASH) gcc-based compiler,
         http://wiki.dlang.org/LDC, ldc $(NDASH) LLVM-based compiler,
         rdmd.html, rdmd $(NDASH) build tool,
-        windbg.html, windbg $(NDASH) debugger,
         htod.html, htod $(NDASH) .h to .d
       )
     $(MENU_W_SUBMENU Books $(AMP) Articles)

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -71,7 +71,7 @@ $(DIVID cssmenu, $(UL
         dmd-windows.html, dmd $(NDASH) reference compiler,
         http://gdcproject.org, gdc $(NDASH) gcc-based compiler,
         http://wiki.dlang.org/LDC, ldc $(NDASH) LLVM-based compiler,
-        rdmd.html, rdmd $(NDASH) pseudo interpreter,
+        rdmd.html, rdmd $(NDASH) build tool,
         windbg.html, windbg $(NDASH) debugger,
         htod.html, htod $(NDASH) .h to .d
       )


### PR DESCRIPTION
...om navigation

Not considered here: overview.html and spec.html.

Adding a new menu section: Compilers & Tools. Adding dmd-windows.html,
rdmd.html, windbg.html, and htod.html. Also adding links to gdc and ldc.
dmd-linux.html, dmd-freebsd.html, and dmd-osx.html can be reached through
dmd-windows.html.

Adding const-faq.html, rationale.html, code_coverage.html, and everything
from SUBNAV_ARTICLES to Books & Articles.

Adding http://wiki.dlang.org/Editors, http://wiki.dlang.org/IDEs, and
glossary.html to Resources.

http://digitalmars.com/ctg/optlink.html is already linked from
dmd-windows.html, good enough.

http://digitalmars.com/ctg/trace.html is already linked from dmd-*.html,
good enough.

Leaving debugger.html dead.

Leaving features2.html and ascii-table.html orphaned, because they don't
add value.

Leaving appendices.html and memory.html orphaned, because they're just
redirects.

----

https://issues.dlang.org/show_bug.cgi?id=14280

A shot of the new menu section:
![iconscreenshot1](https://cloud.githubusercontent.com/assets/9287500/6675440/aaafc8aa-cc20-11e4-92df-a41a6fa9feb3.png)
