### PR TITLE
remove download links from changelog

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -10711,7 +10711,7 @@ Macros:
 	<div class="version">
 	$(B $(LARGE <a name="new2_$1">
 	  Version
-	  <a HREF="http://ftp.digitalmars.com/dmd.2.$1.zip" title="D 2.$1">D 2.$1</a>
+	  <a HREF="http://downloads.dlang.org/releases/2.x/2.$1" title="D 2.$1">D 2.$1</a>
 	))
 	$(SMALL $(I $2, $3))
 	$5


### PR DESCRIPTION
- we have a link on the download page to the release archive
  and the one in the changelog always points to the bundled zip
  which is the least suitable download

- use permalink anchors instead

- also cleanup the anchor names (#2.066.1 instead of #new2_066.1)