### PR TITLE
tabindex for search box

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -78,7 +78,7 @@ $(DIVID navigation,
         <form method="get" action="http://google.com/search">
             <input type="hidden" id="domains" name="domains" value="dlang.org" />
             <input type="hidden" id="sourceid" name="sourceid" value="google-search" />
-            $(SPANID search-query, <input id="q" name="q" placeholder="Search" />)$(SPANID search-dropdown,
+            $(SPANID search-query, <input id="q" name="q" placeholder="Search" tabindex="1000" />)$(SPANID search-dropdown,
                 <select id="sitesearch" name="sitesearch" size="1">
                     <option value="dlang.org">Entire D Site</option>
                     <option $(SEARCHDEFAULT_PHOBOS) value="dlang.org/phobos">Library Reference</option>


### PR DESCRIPTION
- makes the search box the first entriy in the tab order
- use index 1000 to leave room for other tab orders