### PR TITLE
Add D1 style for operator overloading to spec

### DIFF
--- a/operatoroverloading.dd
+++ b/operatoroverloading.dd
@@ -29,6 +29,7 @@ $(SPEC_S Operator Overloading,
 		)
 	)
 	$(LI $(RELATIVE_LINK2 dispatch, Forwarding))
+	$(LI $(RELATIVE_LINK2 old-style, D1 style operator overloading))
 	)
 
 $(H2 $(LEGACY_LNAME2 Unary, unary, Unary Operator Overloading))
@@ -968,6 +969,15 @@ void main()
     assert(d.foo == 8);
 }
 ---
+
+$(H2 $(LEGACY_LNAME2 Old-Style, old-style, D1 style operator overloading))
+
+	$(P 
+        While the preferred style for operator overloading is to use the above
+        mechanisms, the $(LINK2 http://digitalmars.com/d/1.0/operatoroverloading.html, D1 operator overload mechanisms)
+        are still allowed. There is no guarantee that these mechanisms will be
+        supported in the future.
+	)
 )
 
 Macros:


### PR DESCRIPTION
See discussion here: http://forum.dlang.org/post/mfano2$2uuc$47@digitalmars.com