### PR TITLE
move -boundscheck into sorted position

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -383,6 +383,19 @@ $(WINDOWS
 		with the hash symbol ($(CODE #)).
 	  )
 
+	  $(SWITCH $(B -boundscheck=[on|safeonly|off]),
+		controls if bounds checking is enabled.
+		$(UL
+			$(LI $(B on): Bounds checks are enabled for all code. This is the default.)
+			$(LI $(B safeonly): Bounds checks are enabled only in $(D @safe) code.
+								This is the default for $(B -release) builds.)
+			$(LI $(B off): Bounds checks are disabled completely (even in $(D @safe)
+						   code). This option should be used with caution and as a
+						   last resort to improve performance. Confirm turning off
+						   $(D @safe) bounds checks is worthwhile by benchmarking.)
+		)
+	  )
+
 	  $(SWITCH $(B -c),
 		compile only, do not link
 	  )
@@ -621,19 +634,6 @@ dmd -cov -unittest myprog.d
 
 	  $(SWITCH $(B -map),
 		generate a .map file
-	  )
-
-	  $(SWITCH $(B -boundscheck=[on|safeonly|off]),
-		controls if bounds checking is enabled.
-		$(UL
-			$(LI $(B on): Bounds checks are enabled for all code. This is the default.)
-			$(LI $(B safeonly): Bounds checks are enabled only in $(D @safe) code.
-								This is the default for $(B -release) builds.)
-			$(LI $(B off): Bounds checks are disabled completely (even in $(D @safe)
-						   code). This option should be used with caution and as a
-						   last resort to improve performance. Confirm turning off
-						   $(D @safe) bounds checks is worthwhile by benchmarking.)
-		)
 	  )
 
 	  $(SWITCH $(B -noboundscheck),


### PR DESCRIPTION
switches are supposed to be in sorted order