### PR TITLE
remove self-reference to dlang.org

### DIFF
--- a/getstarted.dd
+++ b/getstarted.dd
@@ -4,7 +4,7 @@ $(D_S
 Getting Started,
 
   $(P
-  $(LINK2 http://dlang.org, $(B D)) is a powerful systems programming language. The 
+  $(B D) is a powerful systems programming language. The
   best places to learn are:)
   )
   $(UL
@@ -35,7 +35,7 @@ Getting Started,
   an ever growing list of 3rd-party D programs and libraries.
   )
   )
-  $(P Welcome to $(LINK2 http://dlang.org, $(B D)).
+  $(P Welcome to $(B D).
   )
 
 Macros:


### PR DESCRIPTION
- it's pretty pointless to link from the
  getting started page back to the root