### PR TITLE
Fix for 14428. Add epub and chm download buttons for the language spec.

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -38,7 +38,11 @@ $(H2 Other Downloads)
 
 $(H3 $(LINK2 http://github.com/D-Programming-Language/visuald/releases, VisualD - D Plugin for Visual Studio))
 
-$(H3I D Programming Language Specification) $(BTN http://dlang.org/dlangspec.pdf, pdf) $(BTN http://dlang.org/dlangspec.mobi, mobi)
+$(H3I D Programming Language Specification)
+$(BTN http://dlang.org/dlangspec.pdf, pdf)
+$(BTN http://dlang.org/dlangspec.mobi, mobi)
+$(BTN http://master.dl.sourceforge.net/project/d-apt/files/dlangspec/2.067.0/dlangspec-2.067.0.epub, epub)
+$(BTN http://master.dl.sourceforge.net/project/d-apt/files/dlangspec/2.067.0/dlangspec-2.067.0.chm, chm)
 
 $(H3 $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars C and C++ Compiler Downloads))
 )


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14428