### PR TITLE
Fix Issue 14418

### DIFF
--- a/function.dd
+++ b/function.dd
@@ -1141,7 +1141,7 @@ void test()
 
 void foo(int x, int y, ...)
 {
-    va_list ap;
+    va_list args;
 
     version (X86)
         va_start(args, y);  // y is the last named parameter
@@ -1155,7 +1155,7 @@ void foo(int x, int y, ...)
     static assert(0, "Platform not supported.");
 
     int z;
-    va_arg(ap, z);  // z is set to 5
+    va_arg(args, z);  // z is set to 5
 }
 ------
 

--- a/function.dd
+++ b/function.dd
@@ -1108,7 +1108,7 @@ $(H4 C-style Variadic Functions)
         It has non-D linkage, such as $(D extern (C)):
 
 ------
-extern (C) int foo(int x, int y, ...);
+extern (C) void foo(int x, int y, ...);
 
 foo(3, 4);      // ok
 foo(3, 4, 6.8); // ok, one variadic argument

--- a/function.dd
+++ b/function.dd
@@ -1139,7 +1139,7 @@ void test()
     foo(3, 4, 5);   // first variadic argument is 5
 }
 
-int foo(int x, int y, ...)
+void foo(int x, int y, ...)
 {
     va_list ap;
 
@@ -1193,7 +1193,7 @@ void test()
     foo(3, 4, 5);   // first variadic argument is 5
 }
 
-int foo(int x, int y, ...)
+void foo(int x, int y, ...)
 {
     int z;
 


### PR DESCRIPTION
Fix of issue 14418 ( https://issues.dlang.org/show_bug.cgi?id=14418 ) and an undefined identifier bug in the "C-style variadic function in D" example I found while testing the fix of 14418. I did not fill a bug report for the later.

This is my first pull request. I read http://wiki.dlang.org/Pull_Requests, but I perhaps something important. So any comments are welcomed.

I updated the extern(C) example only for consistency, so 'foo' is void in all examples - the extern(C) example does compile with 
extern (C) int foo(int x, int y, ...);
too, so that change is not important.

An alternative fix would be:
- foo returns int
- add something like "return 42;"
I think that would be rather confusing than helpful.