### PR TITLE
Bump DMD to 2.067.0.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -25,10 +25,10 @@ REMOTE_DIR=d-programming@digitalmars.com:data
 GENERATED=.generated
 
 # stable dub and dmd versions used to build dpl-docs
-DUB_VER=0.9.22
-STABLE_DMD_VER=2.066.1
+DUB_VER=0.9.23
+STABLE_DMD_VER=2.067.0
 STABLE_DMD_ROOT=/tmp/.stable_dmd-$(STABLE_DMD_VER)
-STABLE_DMD_URL=http://downloads.dlang.org/releases/2014/dmd.$(STABLE_DMD_VER).$(OS).zip
+STABLE_DMD_URL=http://downloads.dlang.org/releases/2.x/$(STABLE_DMD_VER)/dmd.$(STABLE_DMD_VER).$(OS).zip
 STABLE_DMD=$(STABLE_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))/dmd
 
 # exclude lists


### PR DESCRIPTION
We really need an URL always pointing to the latest version.