### PR TITLE
Issue 14006 - "Contribute" button/option on the main site and sitemap

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -251,84 +251,125 @@ consistency. $(LINK2 memory-safe-d.html, Read more.))
 
 ))
 
-$(COMMENT Community,
+$(SECTION1 Community,
 
-$(P D is the center of a growing, vibrant community. Get D-related
-news from the $(D digitalmars.D.announce) forum $(TAG2 span,
-style="font-size:80%", $(HTTP
-digitalmars.com/pnews/indexing.php?server=news.digitalmars.com&group=digitalmars.D.announce,
-[browse]) $(LINK2 news://news.digitalmars.com/digitalmars.D.announce,
-[usenet]) $(HTTP
-lists.puremagic.com/cgi-bin/mailman/listinfo/digitalmars-d-announce,
-[mailing list])). On Twitter, subscribe to D's official announcements
-channel, $(HTTP twitter.com/#!/D_Programming,@D_Programming), and
-search for (and disseminate) news using tag $(HTTP
-twitter.com/#!/search/%23dlang, #dlang).)
-
-$(P Learning D and have a question about the best way to do X? The $(D
-digitalmars.D.learn) forum $(TAG2 span, style="font-size:80%", $(HTTP
-digitalmars.com/pnews/indexing.php?server=news.digitalmars.com&group=digitalmars.D.learn,
-[browse]) $(LINK2 news://news.digitalmars.com/digitalmars.D.learn,
-[usenet]) $(HTTP
-lists.puremagic.com/cgi-bin/mailman/listinfo/digitalmars-d-learn,
-[mailing list])) is the hangout place where many D experts are ready
-to help fellow hackers.)
-
-$(P The $(D digitalmars.D) forum $(TAG2 span, style="font-size:80%",
-$(HTTP
-digitalmars.com/pnews/indexing.php?server=news.digitalmars.com&group=digitalmars.D,
-[browse]) $(LINK2 news://news.digitalmars.com/digitalmars.D, [usenet])
-$(HTTP lists.puremagic.com/cgi-bin/mailman/listinfo/digitalmars-d,
-[mailing list])) is the best place to discuss anything and everything
-related to D: language design ideas, suggestions, status and future,
-contributions to the language and its standard library. Reach and
-engage all major D contributors, including the very creator of D,
-$(HTTP walterbright.com, Walter Bright). For real-time conversation, use #d IRC channel on freenode.)
-
-$(SECTION3 To contribute,
-
-$(P Many D enthusiasts are not only using, but also contributing to
-the language, its implementation, and its standard library. The main
-hub of D development is $(HTTP github.com/D-Programming-Language,
-D-Programming-Language on github). The project has been awash in
-contributions ever since creating the github repository on January 23,
-2011, with an average of over 3 pull requests per day. (That doesn't
-mean there's not a lot more to do!) You are welcome to fork any
-subproject ($(HTTP github.com/D-Programming-Language/dmd, compiler),
-$(HTTP github.com/D-Programming-Language/druntime, runtime), $(HTTP
-github.com/D-Programming-Language/phobos, standard library), $(HTTP
-github.com/D-Programming-Language/dlang.org,
-website), $(HTTP github.com/D-Programming-Language/tools, tools), or
-$(HTTP github.com/D-Programming-Language/installer, installer)), change
-it in useful ways, and propose your changes back to the community.
-
-$(P The reference compiler $(LINK2 download.html, dmd) has inspired
-work on alternate implementations that add value by using distinct
-back-ends:)
-
-$(UL
-
-$(LI GNU D compiler $(LINK2 http://bitbucket.org/goshawk/gdc/wiki/Home, gdc).)
-
-$(LI LLVM D Compiler $(HTTP dsource.org/projects/ldc, ldc).)
-
+$(P
+    The D language ecosystem is developed by an ever growing, vibrant
+    community of passionate programmers. To be a part of this community
+    and to keep in touch with recent developments and discussions,
+    please visit the following valuable resources.
 )
 
-$(P The gdc compiler is of particular interest because it taps into
-gcc's extremely portable back-end and large installation base. The D
-development team has signed the appropriate documents with FSF and is
-pursuing integration of gdc with gcc version 4.8 starting March 2012.
-$(HTTPS launchpad.net/~ibuclaw, Iain Buclaw) is leading that
-effort.)
-
+$(SECTION3 Official newsgroups,
+    $(TABLE
+        $(TR
+            $(TH Newsgroup)$(TH Overview)
+        )
+        $(TR
+            $(TD $(HTTP forum.dlang.org/group/digitalmars.D, D))
+            $(TD the best place to discuss anything and everything
+            related to D. Language design ideas, suggestions, current
+            status, future, contributions to the language and its
+            standard library. Reach and engage all major D contributors,
+            including the very creator of D itself, Walter Bright.)
+        )
+        $(TR
+            $(TD $(HTTP forum.dlang.org/group/digitalmars.D.announce,
+            D.announce))
+            $(TD All the latest exciting announcements and news from the
+            D community.)
+        )
+        $(TR
+            $(TD $(HTTP forum.dlang.org/group/digitalmars.D.learn,
+            D.learn))
+            $(TD $(I The) place to ask any question about D. No question
+            is too simple and beginners are very welcome. All current
+            contributors to D answer questions here so it's the premier
+            resource for how things work.)
+        )
+    )
 )
 
-)
+$(SECTION3 Twitter,
+    $(P
+        On Twitter, subscribe to D's official announcements channel,
+        $(HTTP twitter.com/D_Programming, @D_Programming), and search
+        for (and disseminate) news using the
+        $(HTTP twitter.com/hashtag/dlang, #dlang) tag.
+    )
 )
 )
 
+$(SECTION1 Contribute,
 
+$(P
+    Many D enthusiasts are not only using, but also contributing to
+    the language, its implementation, and its standard library. The
+    main hub of D development is
+    $(HTTP github.com/D-Programming-Language, D-Programming-Language)
+    on github. The project has been very rich in contributions
+    ever since creating the github repository on January 23, 2011.
+    You are welcome to fork any repository ($(HTTP
+    github.com/D-Programming-Language/dmd, compiler),
+    $(HTTP github.com/D-Programming-Language/druntime, runtime),
+    $(HTTP github.com/D-Programming-Language/phobos, standard library),
+    $(HTTP github.com/D-Programming-Language/dlang.org, website),
+    $(HTTP github.com/D-Programming-Language/tools, tools), or
+    $(HTTP github.com/D-Programming-Language/installer, installer)),
+    change it in useful ways and propose your changes back to the
+    community.
+)
 
+$(SECTION3 Guides,
+    $(TABLE
+        $(TR
+            $(TH Link)$(TH Overview)
+        )
+        $(TR
+            $(TD $(LINK2 http://wiki.dlang.org/Building_DMD, Building
+            the tool chain))
+            $(TD Step by step instructions on how to build the D tool
+            chain.)
+        )
+        $(TR
+            $(TD $(LINK2 http://wiki.dlang.org/Pull_Requests, Creating
+            pull requests))
+            $(TD Instructions on how to use github to send us your
+            code.)
+        )
+        $(TR
+            $(TD $(LINK2 http://dlang.org/dstyle.html, D code style
+            guidelines))
+            $(TD Guidelines to follow to make sure your code is
+            formatted like everybody else's.)
+        )
+    )
+)
+
+$(SECTION3 Other implementations,
+    $(P
+        The reference compiler $(LINK2 download.html, dmd) has inspired
+        work on alternate implementations that add value by using distinct
+        back-ends:
+    )
+
+    $(UL
+        $(LI GNU D compiler $(HTTP github.com/D-Programming-GDC/GDC, gdc).)
+        $(LI LLVM D Compiler $(HTTP github.com/ldc-developers/ldc, ldc).)
+    )
+
+    $(P
+        The gdc compiler is of particular interest because it taps into
+        gcc's extremely portable back-end and large installation base. The D
+        development team has signed the appropriate documents with FSF and is
+        pursuing integration of gdc with gcc version 4.8 starting March 2012.
+        $(HTTPS launchpad.net/~ibuclaw, Iain Buclaw) is leading that
+        effort.
+    )
+)
+)
+
+)
 
 $(COMMENT
 


### PR DESCRIPTION
It looks like contribution information was present on the main index page but was commented out at some stage. I've re-instated the text and updated it.

* Is this ok on the main index page?
* Please comment on grammar or alternative wording.

All changes can be previewed here: http://nomad.so/misc/d/dlang.org/issue_14006/index.html

Bugzilla: https://issues.dlang.org/show_bug.cgi?id=14006