### PR TITLE
Update garbage.dd

### DIFF
--- a/garbage.dd
+++ b/garbage.dd
@@ -383,7 +383,7 @@ $(H2 D Operations That Involve the Garbage Collector)
 $(H2 References)
 
 	$(UL
-	$(LI $(LINK2 http://en.wikipedia.org/wiki/Garbage_collection_$(PERCENT)28computer_science$(PERCENT)29, Wikipedia))
+	$(LI $(LINK2 http://en.wikipedia.org/wiki/Garbage_collection_%28computer_science%29, Wikipedia))
 	$(LI $(LINK2 http://www.iecc.com/gclist/GC-faq.html, GC FAQ))
 	$(LI $(LINK2 ftp://ftp.cs.utexas.edu/pub/garbage/gcsurvey.ps, Uniprocessor Garbage Collector Techniques))
 	$(LI $(AMAZONLINK 0471941484, Garbage Collection: Algorithms for Automatic Dynamic Memory Management))


### PR DESCRIPTION
fix broken link

was outputting 
    < a href="http://en.wikipedia.org/wiki/Garbage_collection_<!--UNDEFINED MACRO: " percent"--="">28computer_science<!--UNDEFINED MACRO: "PERCENT"-->29"&gt;Wikipedia</a>

before. Maybe undefined macros should trigger a build failure(or warning?)