### PR TITLE
Fix a note that no longer reflects how D works

### DIFF
--- a/statement.dd
+++ b/statement.dd
@@ -1170,9 +1170,8 @@ $(GNAME ContinueStatement):
         $(P Any intervening finally clauses are executed, and any intervening
         synchronization objects are released.)
 
-        $(P $(D Note:) If a finally clause executes a return, throw, or goto
-        out of the finally clause,
-        the continue target is never reached.)
+        $(P $(D Note:) If a finally clause executes a throw out of the finally
+        clause, the continue target is never reached.)
 
 ---
 for (i = 0; i < 10; i++)
@@ -1203,9 +1202,8 @@ $(GNAME BreakStatement):
         $(P Any intervening finally clauses are executed, and any intervening
         synchronization objects are released.)
 
-        $(P $(D Note:) If a finally clause executes a return, throw, or goto
-        out of the finally clause,
-        the break target is never reached.)
+        $(P $(D Note:) If a finally clause executes a throw out of the finally
+        clause, the break target is never reached.)
 
 ---
 for (i = 0; i < 10; i++)


### PR DESCRIPTION
Reasoning:
```
while (1)
{
    try {
        break;
    }
    finally {
        goto label;   // Compiler error
        return 1;     // Compiler error
    }
}
```