### PR TITLE
Update deprecated features table to reflect errors that are infact also gone

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -10,11 +10,11 @@ $(SPEC_S Deprecated Features,
 
     $(TABLE2 Deprecated Features,
         $(THEAD Feature,                                                          Spec,  Warn,   Dep,    Error,  Gone)
-        $(TROW $(DEPLINK Cast T[] to integral type),                              ?,     N/A,    2.060,  2.061,  &nbsp;)
+        $(TROW $(DEPLINK Cast T[] to integral type),                              ?,     N/A,    2.060,  &nbsp;, 2.061 )
         $(TROW $(DEPLINK Base Class Protection),                                  2.058, N/A,    2.058,  2.067,  &nbsp;)
-        $(TROW $(DEPLINK Using length in index expressions),                      ?,     N/A,    2.041,  2.061,  &nbsp;)
+        $(TROW $(DEPLINK Using length in index expressions),                      ?,     N/A,    2.041,  &nbsp;, 2.061 )
         $(TROW $(DEPLINK typedef),                                                2.057, N/A,    2.057,  2.067,  &nbsp;)
-        $(TROW $(DEPLINK Variable shadowing inside functions),                    ?,     N/A,    0.161,  2.061,  &nbsp;)
+        $(TROW $(DEPLINK Variable shadowing inside functions),                    ?,     N/A,    0.161,  &nbsp;, 2.061 )
         $(TROW $(DEPLINK invariant as an alias for immutable),                    2.057, N/A,    2.057,  2.064,  2.066 )
         $(TROW $(DEPLINK Using * to dereference arrays),                          ?,     N/A,    2.057,  2.067,  &nbsp;)
         $(TROW $(DEPLINK Removing an item from an associative array with delete), ?,     N/A,    0.127,  2.061,  2.067 )
@@ -23,7 +23,7 @@ $(SPEC_S Deprecated Features,
         $(TROW $(DEPLINK Escape string literals),                                 ?,     N/A,    2.026,  2.061,  2.067 )
         $(TROW $(DEPLINK Lower case 'l' suffix for integer literals),             ?,     N/A,    1.054,  0.174,  (never) )
         $(TROW $(DEPLINK Octal literals),                                         2.054, N/A,    2.053,  2.067,  &nbsp;)
-        $(TROW $(DEPLINK Upper case 'I' suffix for imaginary literals),           ?,     N/A,    0.154,  2.061,  &nbsp;)
+        $(TROW $(DEPLINK Upper case 'I' suffix for imaginary literals),           ?,     N/A,    0.154,  2.061,  (never) )
         $(TROW $(DEPLINK HTML source files),                                      ?,     N/A,    2.013,  N/A,    2.061 )
         $(TROW $(DEPLINK .typeinfo property),                                     ?,     N/A,    0.093,  2.061,  2.067 )
         $(TROW $(DEPLINK C-style function pointers),                              ?,     N/A,    2.050,  2.067, &nbsp;)


### PR DESCRIPTION
Reasoning:
- Cast T[] to integral type
 - The error given is the same for all invalid casts.
- Using length in index expressions
 - The error given is "undefined identifier length" and not "use '$' instead of length".
- Variable shadowing inside functions
 - This will always be invalid code, and no changes to parsing/semantic will make this anything but.
- Upper case 'I' suffix for imaginary literals
 - This will never be gone until complex types leave the language.  Which is as good as never at this point.