### PR TITLE
More deprecations that were missed/not updated.

### DIFF
--- a/deprecate.dd
+++ b/deprecate.dd
@@ -36,7 +36,7 @@ $(SPEC_S Deprecated Features,
         $(TROW $(DEPLINK .min property for floating point types),                 N/A,    2.061, 2.065,  2.067,  &nbsp;)
         $(TROW $(DEPLINK Imaginary and complex types),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Floating point NCEG operators),                          future, &nbsp;, 2.066,  &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK .sort and .reverse properties for arrays),               future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK .sort and .reverse properties for arrays),               future, 2.067,  &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK clear),                                                  2.060,  &nbsp;, 2.066,  &nbsp;, 2.068)
         $(TROW $(DEPLINK delete),                                                 future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK Overriding without override),                            future, &nbsp;, 2.004,  &nbsp;, &nbsp;)

--- a/deprecate.dd
+++ b/deprecate.dd
@@ -39,7 +39,7 @@ $(SPEC_S Deprecated Features,
         $(TROW $(DEPLINK .sort and .reverse properties for arrays),               future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
         $(TROW $(DEPLINK clear),                                                  2.060,  &nbsp;, 2.066,  &nbsp;, 2.068)
         $(TROW $(DEPLINK delete),                                                 future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
-        $(TROW $(DEPLINK Overriding without override),                            future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
+        $(TROW $(DEPLINK Overriding without override),                            future, &nbsp;, 2.004,  &nbsp;, &nbsp;)
         $(TROW $(DEPLINK scope for allocating classes on the stack),              future, &nbsp;, &nbsp;, &nbsp;, &nbsp;)
     )
 


### PR DESCRIPTION
Overriding without override: https://github.com/D-Programming-Language/dmd/commit/ddead63bc3502113f683dc855afac5bc03777a71#diff-43282ebf5a2de5fdbcb3b5083ddf949dR287

Warn on .sort and .reverse: https://github.com/D-Programming-Language/dmd/commit/dbb24f8ecd31c8e5a03af9008ecd05ba1ec89cb5