### PR TITLE
Issue 14522 - Postfix array declaration examples should be removed from arrays.html

### DIFF
--- a/arrays.dd
+++ b/arrays.dd
@@ -66,16 +66,9 @@ int[] a;
         Multiple dynamic arrays can share all or parts of the array data.
         )
 
-$(H2 Array Declarations)
+$(H2 $(LNAME2 declarations, Array Declarations))
 
-        $(P There are two ways to declare arrays, prefix and postfix.
-        The prefix form is the preferred method, especially for
-        non-trivial types.
-        )
-
-$(H3 Prefix Array Declarations)
-
-        $(P Prefix declarations appear before the identifier being
+        $(P Declarations appear before the identifier being
         declared and read right to left, so:
         )
 
@@ -86,44 +79,6 @@ int[][5] c;   // array of 5 dynamic arrays of ints.
 int*[]*[3] d; // array of 3 pointers to dynamic arrays of pointers to ints
 int[]* e;     // pointer to dynamic array of ints
 ---------
-
-
-$(H3 Postfix Array Declarations)
-
-        $(P Postfix declarations appear after the identifier being
-        declared and read left to right.
-        Each group lists equivalent declarations:
-        )
-
----------
-// dynamic array of ints
-int[] a;
-int a[];
-
-// array of 3 arrays of 4 ints each
-int[4][3] b;
-int[4] b[3];
-int b[3][4];
-
-// array of 5 dynamic arrays of ints.
-int[][5] c;
-int[] c[5];
-int c[5][];
-
-// array of 3 pointers to dynamic arrays of pointers to ints
-int*[]*[3] d;
-int*[]* d[3];
-int* (*d[3])[];
-
-// pointer to dynamic array of ints
-int[]* e;
-int (*e)[];
----------
-
-        $(P $(B Rationale:) The postfix form matches the way arrays are
-        declared in C and C++, and supporting this form provides an
-        easy migration path for programmers used to it.
-        )
 
 $(H2 $(LNAME2 usage, Array Usage))
 


### PR DESCRIPTION
I've removed the deprecated postfix array explanation and example. The removed example also threw lots of warnings and errors.

A preview of the new page can be seen here:
http://nomad.so/misc/d/dlang.org/issue_14522/arrays.html

Bugzilla:
https://issues.dlang.org/show_bug.cgi?id=14522