### PR TITLE
update dpl-docs dependencies manually

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -454,7 +454,7 @@ docs-prerelease.json : ${DMD} ${DRUNTIME_DIR}/.cloned \
 
 .PHONY: dpl-docs
 dpl-docs: ${DUB} ${STABLE_DMD}
-	${DUB} build --root=${DPL_DOCS_PATH} --compiler=${STABLE_DMD}
+	${DUB} build --nodeps --root=${DPL_DOCS_PATH} --compiler=${STABLE_DMD}
 
 ${STABLE_DMD}:
 	mkdir -p ${STABLE_DMD_ROOT}

--- a/win32.mak
+++ b/win32.mak
@@ -347,7 +347,7 @@ docs.json:
 	dir /s /b /a-d ..\phobos\*.d | findstr /V "unittest.d linux osx format.d" >> .tmp/files.txt
 	dmd -c -o- -version=CoreDdoc -version=StdDdoc -Df.tmp/dummy.html -Xfdocs.json @.tmp/files.txt
 	# WORKAROUND FOR DEPENDECY TRACKING BUG IN DUB (issue #331)
-	dub build --force --root $(DPL_DOCS_PATH)
+	dub build --nodeps --force --root $(DPL_DOCS_PATH)
 	#
 	$(DPL_DOCS) filter docs.json --min-protection=Protected --only-documented $(MOD_EXCLUDES_RELEASE)
 	rmdir /s /q .tmp


### PR DESCRIPTION
- to avoid breakage by broken upstream package descriptions
- workaround for https://github.com/D-Programming-Language/dub/issues/564