### PR TITLE
new XREF variant for sub-packages: XREF_PACK

### DIFF
--- a/arrays.dd
+++ b/arrays.dd
@@ -241,7 +241,8 @@ s[1..3] = s[0..2]; // error, overlapping copy
         semantics of C.
         )
         
-        $(P If overlapping is required, use $(FULL_XREF algorithm, copy):
+        $(P If overlapping is required, use
+        $(XREF_PACK algorithm,mutation,copy):
         )
 
 ---------

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -280,6 +280,8 @@ _=
 
 XREF=$(XREF2 $1, $2, $(D std.$1.$2))
 XREF2=$(SPANC libref, $(AHTTP dlang.org/phobos/std_$1.html#$2, $(TAIL $+)))
+XREF_PACK=$(XREF_PACK_NAMED $1, $2, $3, $(D std.$1.$2.$3))
+XREF_PACK_NAMED=$(SPANC libref, $(AHTTP dlang.org/phobos/std_$1_$2.html#$3, $4))
 _=
 
 YELLOW=$(SPANC yellow, $0)

--- a/latex.ddoc
+++ b/latex.ddoc
@@ -85,7 +85,6 @@ _=
 
 FOOTER=
 FOOTNOTE=\footnote{$0}
-FULL_XREF=\href{phobos/std_$1.html#$2}{$(D std.$1.$2)}
 _=
 
 GLINK=$(LINK2 $0, $(I $0))
@@ -354,6 +353,10 @@ VTDX=& $(VERTICAL $1) $(VTDX $+)
 _=
 
 WHITE={\color{white}$0}
+_=
+
+XREF=\href{phobos/std_$1.html#$2}{$(D std.$1.$2)}
+XREF_PACK_NAMED=\href{phobos/std_$1_$2.html#$3}{$4}
 _=
 
 YELLOW={\color{yellow}$0}

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -1,5 +1,6 @@
 D = <code class="prettyprint lang-d">$0</code>
 XREF = std.$1.$2
+XREF_PACK = std.$1.$2.$3
 CXREF = core.$1.$2
 ECXREF = etc.$1.$2
 LREF = $1


### PR DESCRIPTION
A PR for phobos follows that uses to this to fix all the broken package links.

A generic XREF variant for arbitrary package depth would be nice. But the best I could think of has a weird parameter order:

```d
XREF_DEEP=$(XREF_DEEP_NAMED std$(XREF_DEEP_PREPEND_DOTS $+,$1),$1,$+)
XREF_DEEP_NAMED=$(SPANC libref,$(AHTTP dlang.org/phobos/$(XREF_DEEP_FILE $+).html#$2,$1))
XREF_DEEP_FILE=std$(XREF_DEEP_PREPEND_UNDERSCORES $+)
XREF_DEEP_PREPEND_UNDERSCORES=$(UNDERSCORE)$1$(XREF_DEEP_PREPEND_UNDERSCORES $+)
XREF_DEEP_PREPEND_DOTS=.$1$(XREF_DEEP_PREPEND_DOTS $+)
```

So I went with another hard-coded version instead.