### PR TITLE
Don't load two additional fonts used solely for site navigation

### DIFF
--- a/css/cssmenu.css.dd
+++ b/css/cssmenu.css.dd
@@ -2,9 +2,7 @@ Ddoc
 
 /*Adapted from http://cssmenumaker.com/menu/modern-jquery-accordion-menu
 */
-@import url(http://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
 
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600,300);
 @charset "UTF-8";
 /* Base Styles */
 #cssmenu,
@@ -19,7 +17,6 @@ Ddoc
   font-weight: normal;
   text-decoration: none;
   line-height: 1;
-  font-family: 'Open Sans', sans-serif;
   font-size: 14px;
   position: relative;
 }
@@ -34,7 +31,7 @@ Ddoc
 }
 #cssmenu > ul > li:first-child > a {
   border: none;
-  font-family: 'Ubuntu', sans-serif;
+  font-family: 'Ubuntu', "Lucida Grande", "Helvetica Neue", Roboto, "Segoe UI", Calibri, Arial, sans-serif;
   text-align: center;
   font-size: 18px;
   font-weight: 300;


### PR DESCRIPTION
cssmenu.css.dd was pulling in two extra fonts (carried over from [the original version](http://cssmenumaker.com/menu/modern-jquery-accordion-menu)). I'm not convinced we need them - they're used only for navigation, and thus are a mostly pointless gimmicks that increase page load time.

Before  | After
------------- | -------------
![](http://dump.thecybershadow.net/77ccea6395f1bf961bbba2faa41b7139/Screen%20Shot%202015-05-15%20at%2001.28.06.png)  | ![](http://dump.thecybershadow.net/8f08bca07f051d757b18eb52ff035cf4/Screen%20Shot%202015-05-15%20at%2001.27.56.png)
