### PR TITLE
Add 'UDA' to glossary

### DIFF
--- a/glossary.dd
+++ b/glossary.dd
@@ -30,12 +30,12 @@ $(DL
 	)
 
 	$(DT $(LEGACY_LNAME2 data_race, data-race, Data Race)) $(DD Two or more threads writing to
-	the same memory location. Program behavior may depend on the arbitrary 
+	the same memory location. Program behavior may depend on the arbitrary
 	sequencing of these memory accesses.
 	)
 
 	$(DT $(LNAME2 functor, Functor)) $(DD A user-defined type (struct or
-	class) that defines the function call operator ($(D opCall) in D) so it 
+	class) that defines the function call operator ($(D opCall) in D) so it
 	can be used similarly to a function.
 	)
 
@@ -55,7 +55,7 @@ $(DL
     $(DT $(LNAME2 ifti, $(ACRONYM IFTI, Implicit Function Template Instantiation)))
 	$(DD Refers to the ability to instantiate a template function
     without having to explicitly pass in the types to the template.
-    Instead, the types are infered automatically from the types of the 
+    Instead, the types are infered automatically from the types of the
     runtime arguments.)
 
 	$(DT Illegal)
@@ -225,6 +225,9 @@ void test()
 	A buffer overflow is an example of undefined behavior.
 	)
 
+	$(DT $(LNAME2 uda, $(ACRONYM UDA, User-Defined Attribute)))
+	$(DD $(LINK2 attribute.html#uda, $(I User-defined attributes)) are metadata
+	attached to symbols used for compile-time reflection.)
 )
 
 )


### PR DESCRIPTION
This also seems to clean up some trailing whitespace.