### PR TITLE
minor improvements to unittest.dd

### DIFF
--- a/unittest.dd
+++ b/unittest.dd
@@ -24,11 +24,13 @@ unittest
     $(P There can be any number of unit test functions in a module,
     including within struct, union and class declarations.
     They are executed in lexical order.
+    The order in which the modules are called to run their unit tests is
+    implementation defined.
     Stylistically, a unit test for a function should appear immediately
     following it.
     )
 
-    $(P A compiler switch, such as $(DDSUBLINK dmd-windows, switches, $(B -unittest))
+    $(P A compiler switch, such as $(DDSUBLINK dmd-windows, switch-unittest, $(B -unittest))
     for $(B dmd), will
     cause the unittest test code to be compiled and incorporated into
     the resulting executable. The unittest code gets run after
@@ -36,12 +38,11 @@ unittest
     function is called.
     )
 
-    $(P Additionally, this switch enables the conditional $(D version(unittest)) statement,
-    enabling your code to take a different path depending on whether you're compiling with
-    unittests or not.
-    )
+    $(P $(GLINK UnitTest)s must be grammatically correct even if $(B -unittest) is not
+    used.)
 
-    $(P For example, given a class Sum that is used to add two values:)
+    $(P For example, given a class $(D Sum) that is used to add two values, a unit
+    test can be given:)
 
 ------
 class Sum


### PR DESCRIPTION
1. specify order
2. fix link to switch
3. remove redundant `-version(unittest)` doc
4. make statement a bit nicer