### PR TITLE
posix.mak: Fix clean builds

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -230,11 +230,11 @@ ${GENERATED}/${LATEST}.ddoc :
 	mkdir -p $(dir $@)
 	echo "LATEST=${LATEST}" >$@
 
-${GENERATED}/modlist-${LATEST}.ddoc : modlist.d $(DRUNTIME_DIR)-$(LATEST)/.cloned $(PHOBOS_DIR)-$(LATEST)/.cloned
+${GENERATED}/modlist-${LATEST}.ddoc : modlist.d $(DMD) $(DRUNTIME_DIR)-$(LATEST)/.cloned $(PHOBOS_DIR)-$(LATEST)/.cloned
 	mkdir -p $(dir $@)
 	$(RDMD) modlist.d $(DRUNTIME_DIR)-$(LATEST) $(PHOBOS_DIR)-$(LATEST) $(MOD_EXCLUDES_RELEASE) >$@
 
-${GENERATED}/modlist-prerelease.ddoc : modlist.d $(DRUNTIME_DIR)/.cloned $(PHOBOS_DIR)/.cloned
+${GENERATED}/modlist-prerelease.ddoc : modlist.d $(DMD) $(DRUNTIME_DIR)/.cloned $(PHOBOS_DIR)/.cloned
 	mkdir -p $(dir $@)
 	$(RDMD) modlist.d $(DRUNTIME_DIR) $(PHOBOS_DIR) $(MOD_EXCLUDES_PRERELEASE) >$@
 


### PR DESCRIPTION
The modlist-*.ddoc files require DMD, so the first make run will fail.