### PR TITLE
Revert "added ddoc for #4619"

### DIFF
--- a/version.dd
+++ b/version.dd
@@ -291,7 +291,6 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D BigEndian)) , $(ARGS Byte order, most significant first))
 	$(TROW $(ARGS $(D D_Coverage)) , $(ARGS $(DPLLINK code_coverage.html, Code coverage analysis) instrumentation (command line $(DDSUBLINK dmd-windows, switches, switch) $(D -cov)) is being generated))
 	$(TROW $(ARGS $(D D_Ddoc)) , $(ARGS $(DDLINK ddoc, Embedded Documentation, Ddoc) documentation (command line $(DDSUBLINK dmd-windows, switches, switch) $(D -D)) is being generated))
-	$(TROW $(ARGS $(D D_Warnings)) , dmd warnings are activated (command line $(DDSUBLINK dmd-windows, switches, switch) $(D -w) or $(D -wi)))
 	$(TROW $(ARGS $(D D_InlineAsm_X86)) , $(ARGS $(DDLINK iasm, Inline Assembler, Inline assembler) for X86 is implemented))
 	$(TROW $(ARGS $(D D_InlineAsm_X86_64)) , $(ARGS $(DDLINK iasm, Inline Assembler, Inline assembler) for X86-64 is implemented))
 	$(TROW $(ARGS $(D D_LP64)) , $(ARGS $(B Pointers) are 64 bits (command line $(DDSUBLINK dmd-windows, switches, switch) $(D -m64)). (Do not confuse this with C's LP64 model)))


### PR DESCRIPTION
Reverts D-Programming-Language/dlang.org#982

The compiler change was already reverted in: https://github.com/D-Programming-Language/dmd/pull/4670
