### PR TITLE
[dwarf] Remove documentation on outdated dwarf extensions

### DIFF
--- a/abi.dd
+++ b/abi.dd
@@ -950,36 +950,6 @@ $(SECTION3 $(LNAME2 codeview, Codeview Debugger Extensions),
 	)
 )
 
-$(SECTION3 $(LNAME2 dwarf, Dwarf Debugger Extensions),
-	$(P The following leaf types are added:)
-
-	$(TABLE2 Dwarf Extensions for D,
-	$(THEAD D type, ID, Value, Format)
-	$(TROW $(ARGS dynamic array)
-	, $(ARGS $(D DW_TAG_darray_type))
-	, $(ARGS 0x41)
-	, $(ARGS $(D DW_AT_type) is element type))
-	$(TROW
-	$(ARGS associative array)
-	, $(ARGS $(D DW_TAG_aarray_type))
-	, $(ARGS 0x42)
-	, $(ARGS $(D DW_AT_type) is element type, $(D DW_AT_containing_type) key type))
-	$(TROW $(ARGS delegate)
-	, $(ARGS $(D DW_TAG_delegate_type))
-	, $(ARGS 0x43)
-	, $(ARGS $(D DW_AT_type) is function type, $(D DW_AT_containing_type) is $(SINGLEQUOTE this) type)))
-
-	$(P These extensions can be pretty-printed
-	by $(LINK2 http://www.digitalmars.com/ctg/dumpobj.html, dumpobj).
-
-	$(P The $(LINK2 https://zerobugs.codeplex.com, ZeroBUGS)
-	debugger supports them.)
-	)
-
-	$(P Note that these Dwarf extensions have been removed as they conflict with
-	recent gcc additions.
-	)
-)
 )
 )
 

--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -491,10 +491,9 @@ dmd -cov -unittest myprog.d
 		$(LINK2 http://ddbg.mainia.de/releases.html, Ddbg)
     )
     $(UNIX
-		add Dwarf symbolic debug info with
-		$(LINK2 abi.html#dwarf, D extensions)
-		for debuggers $(LINUX such as
-		$(LINK2 https://zerobugs.codeplex.com, ZeroBUGS))
+		add symbolic debug info in Dwarf format
+		for debuggers such as
+		$(D gdb)
     )
 	  )
 
@@ -505,9 +504,8 @@ dmd -cov -unittest myprog.d
 		$(D $(DMDDIR)\bin\windbg)
     )
     $(UNIX
-		add Dwarf symbolic debug info in C format
-		for debuggers such as
-		$(D gdb)
+		backwards compatibility option for the
+		the $(SWLINK -g) switch
     )
 	  )
 


### PR DESCRIPTION
Complimentary to  https://github.com/D-Programming-Language/dmd/pull/4732