### PR TITLE
Minor updates to SIMD.dd documentation

### DIFF
--- a/simd.dd
+++ b/simd.dd
@@ -6,7 +6,7 @@ $(SPEC_S Vector Extensions,
 	operations, sometimes called "media instructions".
 	Vector types are a fixed array of floating or integer types, and
 	vector operations operate simultaneously on them, thus achieving
-	great speedups.)
+	great speed-ups.)
 
 	$(P When the compiler takes advantage of these instructions with standard D code
 	to speed up loops over arithmetic data, this is called auto-vectorization.
@@ -57,9 +57,14 @@ import core.simd;
 ---
 
 	$(P These types and operations will be the ones defined for the architecture
-	the compiler is targetting. If a particular CPU family has varying
+	the compiler is targeting. If a particular CPU family has varying
 	support for vector types, an additional runtime check may be necessary.
-	The compiler does not emit runtime checks; those must be done by the programmer.
+	The compiler does not emit runtime checks; those must be done by the 
+	programmer.
+	)
+	
+	$(P Depending on the architecture, compiler flags may be required to  
+	activate support for SIMD types.
 	)
 
 	$(P The types defined will all follow the naming convention:)
@@ -93,7 +98,7 @@ $(H3 Conversions)
 
 ---
 int4 v = 7;
-v = 3 * v;   // multiply each element in v by 3
+v = 3 + v;   // add 3 to each element in v
 ---
 
 $(H3 Accessing Individual Vector Elements)


### PR DESCRIPTION
A few changes to SIMD.dd, mainly continuing my earlier attempt to provide some additional details on getting it to work in practice with compiler flags. In addition, I fixed an issue with one of the examples not compiling (at least for me). I also fixed some minor spelling issues.