### PR TITLE
Revert "Fix for 14428. Add epub and chm download buttons for the lang…

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -38,11 +38,7 @@ $(H2 Other Downloads)
 
 $(H3 $(LINK2 http://github.com/D-Programming-Language/visuald/releases, VisualD - D Plugin for Visual Studio))
 
-$(H3I D Programming Language Specification)
-$(BTN http://dlang.org/dlangspec.pdf, pdf)
-$(BTN http://dlang.org/dlangspec.mobi, mobi)
-$(BTN http://master.dl.sourceforge.net/project/d-apt/files/dlangspec/2.067.0/dlangspec-2.067.0.epub, epub)
-$(BTN http://master.dl.sourceforge.net/project/d-apt/files/dlangspec/2.067.0/dlangspec-2.067.0.chm, chm)
+$(H3I D Programming Language Specification) $(BTN http://dlang.org/dlangspec.pdf, pdf) $(BTN http://dlang.org/dlangspec.mobi, mobi)
 
 $(H3 $(LINK2 http://www.digitalmars.com/download/freecompiler.html, Digital Mars C and C++ Compiler Downloads))
 )


### PR DESCRIPTION
Reverts D-Programming-Language/dlang.org#966

The download links are already dead and we don't want another chm file.
An integration of epub generation into dlang.org would be appreciated though.