### PR TITLE
state that casting away const and then mutating is undefined behaviour

### DIFF
--- a/const3.dd
+++ b/const3.dd
@@ -284,10 +284,10 @@ auto p = s.idup;
 p[0] = ...;	  // error, p[] is immutable
 ---
 
-$(H2 Removing Immutable With A Cast)
+$(H2 Removing Immutable or Const with a Cast)
 
 	$(P
-	The immutable type can be removed with a cast:
+	An immutable or const type qualifier can be removed with a cast:
 	)
 
 ---
@@ -312,6 +312,23 @@ int* q = cast(int*)p;
 	the responsibility to ensure the immutableness of the data, as
 	the compiler will no longer be able to statically do so.
 	)
+
+	$(P
+	Note that casting away a const qualifier and then mutating is undefined
+	behavior, too, even when the referenced data is mutable. This is so that
+	compilers and programmers can make assumptions based on const alone. For
+	example, here it may be assumed that $(D f) does not alter $(D x):
+	)
+
+---
+void f(const int* a);
+void main()
+{
+    int x = 1;
+    f(&x);
+    assert(x == 1); // guaranteed to hold
+}
+---
 )
 
 

--- a/const3.dd
+++ b/const3.dd
@@ -226,7 +226,7 @@ s = null;    // ok, s itself is not immutable
 ---
 
 	$(P
-	Immutableness is transitive, meaning it applies to anything that
+	Immutability is transitive, meaning it applies to anything that
 	can be referenced from the immutable type:
 	)
 
@@ -309,7 +309,7 @@ int* q = cast(int*)p;
 	as when referencing code in a library one cannot change.
 	Casting is, as always, a blunt and effective instrument, and
 	when using it to cast away immutable-correctness, one must assume
-	the responsibility to ensure the immutableness of the data, as
+	the responsibility to ensure the immutability of the data, as
 	the compiler will no longer be able to statically do so.
 	)
 


### PR DESCRIPTION
Related discussion: http://forum.dlang.org/post/riiehqozpkyluhhifwha@forum.dlang.org

I think there's a consensus now that casting away const and then mutating is always undefined behaviour.

Drive-by style fixes: title case, "immutableness" -> "immutability"