### PR TITLE
Remove dependency of dmd on .cloned

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -331,10 +331,10 @@ dlangspec.verbatim.txt : $(DMD) verbatim.ddoc dlangspec-consolidated.d
 # dmd compiler, latest released build and current build
 ################################################################################
 
-$(DMD) : ${DMD_DIR}/.cloned
+$(DMD):
 	${MAKE} --directory=${DMD_DIR}/src -f posix.mak -j 4
 
-$(DMD_REL) : ${DMD_DIR}-${LATEST}/.cloned
+$(DMD_REL):
 	${MAKE} --directory=${DMD_DIR}-${LATEST}/src -f posix.mak -j 4
 
 ################################################################################


### PR DESCRIPTION
cc @MartinNowak 

Sadly the dependency of `dmd` on `.clone` does not work out.

Consider a user who wants to build `dlang.org` and has a preexisting `dmd` created by other means (i.e. there's no `../dmd/.cloned` directory) and built properly. Then, trying to make dlang.org will follow an unpleasant sequence of events:

1. There's no `../dmd/.cloned` so it will execute the rule for it. The rule uses `touch` to create a `../dmd/.cloned` that is NEWER than the prebuilt `../dmd/src/dmd`. 

2. Following that, the rule attempts to build `../dmd/src/dmd`. The rule will issue `make` in `dmd`'s directory, which in turn requires that either dmd had been installed so it's usable for bootstrapping, or AUTO_BOOTSTRAP=1 is used in the command line (which isn't).

It's nice to have the build of dlang.org attempt to build the entire world of dependencies needed for it to work, but having it require boostrapping paraphernalia etc. seems excessive, particularly when `../dmd/src/dmd` is present and functional. So this PR removes the dependency on `.cloned`. The build will be attempted only if `../dmd/src/dmd` is actually absent.