### PR TITLE
fix tuple.dd and ctarguments.dd (issue 14879)

### DIFF
--- a/ctarguments.dd
+++ b/ctarguments.dd
@@ -219,4 +219,4 @@ $(P TODO)
 )
 
 Macros:
-TITLE=Compile-Time Lists
+    TITLE=Compile-Time Lists

--- a/ctarguments.dd
+++ b/ctarguments.dd
@@ -215,3 +215,8 @@ static assert ([ Arguments!(1, 2, 3) ] == [ 1, 2, 3 ]);
 $(H3 Further reading)
 
 $(P TODO)
+
+)
+
+Macros:
+TITLE=Compile-Time Lists

--- a/doc.ddoc
+++ b/doc.ddoc
@@ -100,6 +100,7 @@ $(DIVID cssmenu, $(UL
         regular-expression.html, Regular Expressions,
         safed.html, SafeD,
         templates-revisited.html, Templates Revisited,
+        ctarguments.html, Compile-Time Lists,
         tuple.html, Tuples,
         variadic-function-templates.html, Variadic Templates,
         d-array-article.html, D Slices

--- a/posix.mak
+++ b/posix.mak
@@ -155,7 +155,7 @@ SPEC_DD=$(addsuffix .dd,$(SPEC_ROOT))
 # $(SPEC_ROOT), the list is sorted alphabetically.
 PAGES_ROOT=$(SPEC_ROOT) 32-64-portability acknowledgements ascii-table		\
 	bugstats.php builtin changelog code_coverage concepts const-faq COM	\
-	comparison cpptod ctod D1toD2 d-array-article d-floating-point		\
+	comparison cpptod ctarguments ctod D1toD2 d-array-article d-floating-point \
 	deprecate dll dll-linux dmd-freebsd dmd-linux dmd-osx dmd-windows	\
 	download dstyle exception-safe faq features2 forum-template gpg_keys getstarted glossary gsoc2011 \
 	gsoc2012 gsoc2012-template hijack howto-promote htod htomodule index intro \

--- a/tuple.dd
+++ b/tuple.dd
@@ -1,7 +1,10 @@
 Ddoc
 
 For documentation on tuples that are commonly present in other languages (anonymous runtime entity that groups
-different values) refer to $(LINK2 std_typecons.html#tuple, Phobos documentation on std.typecons.tuple)
+different values) refer to $(LINK2 phobos/std_typecons.html#tuple, Phobos documentation on std.typecons.tuple)
 
 You may be also looking for documentation for built-in $(LINK2 ctarguments.html, compile-time argument lists)
 which can be sometimes referred as "tuples" too (though it is discouraged).
+
+Macros:
+TITLE=Tuples

--- a/tuple.dd
+++ b/tuple.dd
@@ -7,4 +7,4 @@ You may be also looking for documentation for built-in $(LINK2 ctarguments.html,
 which can be sometimes referred as "tuples" too (though it is discouraged).
 
 Macros:
-TITLE=Tuples
+    TITLE=Tuples

--- a/win32.mak
+++ b/win32.mak
@@ -17,7 +17,7 @@ SRC= $(SPECSRC) cpptod.dd ctod.dd pretod.dd cppcontracts.dd index.dd overview.dd
 	const-faq.dd concepts.dd d-floating-point.dd migrate-to-shared.dd	\
 	D1toD2.dd intro-to-datetime.dd simd.dd deprecate.dd download.dd		\
 	32-64-portability.dd dll-linux.dd bugstats.php.dd getstarted.dd \
-	css\cssmenu.css.dd \
+	css\cssmenu.css.dd ctarguments.dd \
 	
 
 SPECSRC=spec.dd intro.dd lex.dd grammar.dd module.dd declaration.dd type.dd property.dd	\
@@ -58,7 +58,7 @@ TARGETS=cpptod.html ctod.html pretod.html cppcontracts.html index.html overview.
 	D1toD2.html unittest.html hash-map.html intro-to-datetime.html		\
 	simd.html deprecate.html download.html 32-64-portability.html		\
 	d-array-article.html dll-linux.html bugstats.php.html getstarted.html \
-	gpg_keys.html forum-template.html css/cssmenu.css \
+	gpg_keys.html forum-template.html css/cssmenu.css ctarguments.html \
 
 # exclude list
 MOD_EXCLUDES_RELEASE=--ex=gc. --ex=rt. --ex=core.internal. --ex=core.stdc.config --ex=core.sys. \
@@ -127,6 +127,8 @@ cpp_interface.html : $(DDOC) cpp_interface.dd
 cppcontracts.html : $(DDOC) cppcontracts.dd
 
 cpptod.html : $(DDOC) cpptod.dd
+
+ctarguments.html : $(DDOC) ctarguments.dd
 
 ctod.html : $(DDOC) ctod.dd
 


### PR DESCRIPTION
Fix link to std.typecons.tuple.
Add ctarguments.dd to make files so that ctarguments.html gets built.
Add missing parenthesis in ctarguments.dd.
Add TITLEs to tuple.dd and ctarguments.dd.
Add ctarguments.html to the menu.

Fixes issue 14879 - tuple documentation broken link.

https://issues.dlang.org/show_bug.cgi?id=14879