### PR TITLE
use "official" copy for code.dlang.org link

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -55,7 +55,7 @@ $(DIVID cssmenu, $(UL
         simd.html, Vector Extensions
       )
     $(MENU phobos/index.html, Standard library)
-    $(MENU http://code.dlang.org, More libraries)
+    $(MENU http://code.dlang.org, DUB $(NDASH) The D package registry)
     $(MENU_W_SUBMENU Community)
       $(SUBMENU
         http://forum.dlang.org, Forums,
@@ -71,7 +71,7 @@ $(DIVID cssmenu, $(UL
         dmd-windows.html, dmd $(NDASH) reference compiler,
         http://gdcproject.org, gdc $(NDASH) gcc-based compiler,
         http://wiki.dlang.org/LDC, ldc $(NDASH) LLVM-based compiler,
-        http://code.dlang.org/download, DUB $(NDASH) The D package registry, 
+        http://code.dlang.org/download, DUB $(NDASH) D package manager,
         https://github.com/Hackerpilot/dfix, dfix $(NDASH) D source code upgrade,
         https://github.com/Hackerpilot/dfmt, dfmt $(NDASH) D source code formatting tool,
         rdmd.html, rdmd $(NDASH) build tool,


### PR DESCRIPTION
- and rename dub tool download to package manager