### PR TITLE
portability.dd: assert should be static assert

### DIFF
--- a/portability.dd
+++ b/portability.dd
@@ -42,11 +42,11 @@ a + b + c
 	$(LI Avoid dependence on the size of a pointer or reference being
 	the same size as a particular integral type.)
 
-	$(LI If size dependencies are inevitable, put an $(D assert) in
+	$(LI If size dependencies are inevitable, put a $(D static assert) in
 	the code to verify it:
 
 -------
-assert(int.sizeof == (int*).sizeof);
+static assert(int.sizeof == (int*).sizeof);
 -------
 	)
 	)


### PR DESCRIPTION
This can be asserted at compile time, and that is generally want you want.

(should I open a bugzilla issue before submitting these kinds of changes?)