### PR TITLE
fix 14879 - tuple documentation broken link

### DIFF
--- a/tuple.dd
+++ b/tuple.dd
@@ -5,3 +5,6 @@ different values) refer to $(LINK2 phobos/std_typecons.html#tuple, Phobos docume
 
 You may be also looking for documentation for built-in $(LINK2 ctarguments.html, compile-time argument lists)
 which can be sometimes referred as "tuples" too (though it is discouraged).
+
+Macros:
+    TITLE=Tuples

--- a/tuple.dd
+++ b/tuple.dd
@@ -1,7 +1,7 @@
 Ddoc
 
 For documentation on tuples that are commonly present in other languages (anonymous runtime entity that groups
-different values) refer to $(LINK2 std_typecons.html#tuple, Phobos documentation on std.typecons.tuple)
+different values) refer to $(LINK2 phobos/std_typecons.html#tuple, Phobos documentation on std.typecons.tuple)
 
 You may be also looking for documentation for built-in $(LINK2 ctarguments.html, compile-time argument lists)
 which can be sometimes referred as "tuples" too (though it is discouraged).


### PR DESCRIPTION
This is what was in #1052 (closed) but not in #1038 (merged).

https://issues.dlang.org/show_bug.cgi?id=14879