### PR TITLE
Update changelog.dd

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -102,7 +102,7 @@ bytes allocated, type, function, file:line
 $(LI $(LNAME2 lex-only-unittest, `unittest` blocks no longer parsed unless `-unittest` is specified:)
 
     $(P When the unittest code is not necessary, it will be merely analyzed
-        as the tokens enclosed with paired braces, to speed up compilation speed.
+        as the tokens enclosed with paired braces, to speed up compilation.
     )
 
         ---


### PR DESCRIPTION
Removed duplicate use of the word speed.