### PR TITLE
LEADINGROW should extend across entire table, not just 2 columns.

### DIFF
--- a/std.ddoc
+++ b/std.ddoc
@@ -16,6 +16,7 @@ LREF = <a href="#$1">$(D $1)</a>
 _=
 
 LEADINGROW = <tr class=leadingrow><td colspan=2><b><em>$(NBSP)$(NBSP)$(NBSP)$(NBSP)$0</em></b></td></tr>
+LEADINGROWN = <tr class=leadingrow><td colspan=$1><b><em>$(NBSP)$(NBSP)$(NBSP)$(NBSP)$+</em></b></td></tr>
 TABLE = <table cellspacing=0 cellpadding=5><caption>$1</caption>$2</table>
 TD = <td>$0</td>
 TDNW = <td class="donthyphenate" nowrap>$0</td>


### PR DESCRIPTION
Thankfully, the HTML spec specifies that a `rowspan` value of `0` will do exactly this.

This affects ddoc tables wider than 2 columns, for example the container primitives table in `phobos/std/container/package.d` (see: http://dlang.org/phobos-prerelease/std_container.html).