### PR TITLE
use binary gpg signatures instead of ASCII armored ones (.asc -> .sig)

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -76,7 +76,7 @@ Macros:
 	UBUNTU=$(LOGO ubuntu, Ubuntu)
 	WINDOWS=$(LOGO windows, Windows)
 
-    SBTN=$(SPANC sig_btn,$(BTN $1,$+)<br>$(BTN $1.asc,sig))
+    SBTN=$(SPANC sig_btn,$(BTN $1,$+)<br>$(BTN $1.sig,sig))
     BTN=<a href="$1" class="btn">$+</a>
     H3I=<h3 class="download">$0</h3>
     DLSITE=http://downloads.dlang.org/releases/2.x/$(DMDV2)/$0


### PR DESCRIPTION
- makes the signatures downloadable by default
  instead of showing them in the browser