### PR TITLE
Specify that pragma(inline, true) can omit stand-alone functions

### DIFF
--- a/pragma.dd
+++ b/pragma.dd
@@ -94,10 +94,15 @@ pragma(inline, false)
 ---
 pragma(inline, true)
 ---
-        If a function cannot be inlined with the $(DDSUBLINK dmd-windows, switch-inline, $(TT -inline))
+        $(P If a function cannot be inlined with the $(DDSUBLINK dmd-windows, switch-inline, $(TT -inline))
         switch, an error message is issued. This is expected to be improved in the future to causing
         functions to always be inlined regardless of compiler switch settings. Whether a compiler can
-        inline a particular function or not is implementation defined.
+        inline a particular function or not is implementation defined.)
+
+        $(P A compiler may choose not to emit a stand-alone copy of the function if this pragma is used.
+        This allows reducing the size of executables or libraries and is especially useful for templated functions.
+        If a compiler applies this optimization, the function does no longer have a valid address. Because of this it is forbidden
+        to take the address of a function annotated with this pragma.)
         )
       )
 ---


### PR DESCRIPTION
As discussed here: http://forum.dlang.org/post/mailman.391.1440162972.13986.digitalmars-d@puremagic.com

If we want to replace some of the druntime RTTI interfaces with templated functions we need to make sure that these template instances don't bloat executables. One solution is to use a force-inline  mechanism and do not generate function code in object files for these functions.

This change is also useful in other cases (heavily templated code with very small functions). We could also decide that `pragma(inline, true)` should always emit a function body. Either way we should specify whether taking the address of a `pragma(inline, true)` function is legal.

ping @WalterBright @andralex