### PR TITLE
Revert "Remove dependency of dmd on .cloned"

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -337,10 +337,10 @@ dlangspec.verbatim.txt : $(DMD) verbatim.ddoc dlangspec-consolidated.d
 # dmd compiler, latest released build and current build
 ################################################################################
 
-$(DMD):
+$(DMD) : ${DMD_DIR}/.cloned
 	${MAKE} --directory=${DMD_DIR}/src -f posix.mak -j 4
 
-$(DMD_REL):
+$(DMD_REL) : ${DMD_DIR}-${LATEST}/.cloned
 	${MAKE} --directory=${DMD_DIR}-${LATEST}/src -f posix.mak -j 4
 
 ################################################################################


### PR DESCRIPTION
Reverts D-Programming-Language/dlang.org#1050

Fixes [issue 14915 - [REG2.068.0] can't build phobos-release](https://issues.dlang.org/show_bug.cgi?id=14915)

I don't know how to do properly what #1050 aimed for. In the short term, I think it's more important to get a working build again.