### PR TITLE
Changelog 2.068: move "Many phobos functions were rangified" to Library Changes

### DIFF
--- a/changelog/2.068.0.dd
+++ b/changelog/2.068.0.dd
@@ -109,74 +109,6 @@ $(LI $(LNAME2 lex-only-unittest, `unittest` blocks no longer parsed unless `-uni
 
 $(BUGSTITLE Language Changes,
 
-$(LI $(LNAME2 rangified-functions, Many phobos functions were rangified.)
-
-    $(P Many phobos functions that allocated GC memory were changed to support
-        ranges or were complemented by an alternative supporting ranges.
-        Using ranges often eliminates GC allocations.
-    )
-
-        ---
-        setExtension("foo.jpg", ".png"); // allocates a new string
-        withExtension("foo.jpg", ".png"); // returns a range without allocating
-        ---
-
-    $(BOOKTABLE Rangified Functions:,
-        $(TR $(TH Module) $(TH Functions)
-        )
-        $(TR $(TD $(STDMODREF algorithm_comparison, std.algorithm.comparison))
-            $(TD
-                $(XREF algorithm_comparison, levenshteinDistance)
-            )
-        )
-        $(TR $(TD $(STDMODREF path, std.path))
-            $(TD
-                $(XREF path, asAbsolutePath)
-                $(XREF path, asNormalizedPath)
-                $(XREF path, asRelativePath)
-                $(XREF path, chainPath)
-                $(XREF path, dirName)
-                $(XREF path, driveName)
-                $(XREF path, filenameCmp)
-                $(XREF path, globMatch)
-                $(XREF path, isValidFilename)
-                $(XREF path, isValidPath)
-                $(XREF path, pathSplitter)
-                $(XREF path, rootName)
-                $(XREF path, stripExtension)
-                $(XREF path, withDefaultExtension)
-                $(XREF path, withExtension)
-            )
-        )
-        $(TR $(TD $(STDMODREF string, std.string))
-            $(TD
-                $(XREF string, centerJustifier)
-                $(XREF string, chomp)
-                $(XREF string, chompPrefix)
-                $(XREF string, chop)
-                $(XREF string, column)
-                $(XREF string, detabber)
-                $(XREF string, entabber)
-                $(XREF string, indexOf)
-                $(XREF string, leftJustifier)
-                $(XREF string, makeTransTable)
-                $(XREF string, rightJustifier)
-                $(XREF string, soundexer)
-                $(XREF string, strip)
-                $(XREF string, stripLeft)
-                $(XREF string, stripRight)
-            )
-        )
-        $(TR $(TD $(STDMODREF uni, std.uni))
-            $(TD
-                $(XREF uni, asCapitalized)
-                $(XREF uni, asLowerCase)
-                $(XREF uni, asUpperCase)
-            )
-        )
-    )
-)
-
 $(LI $(LNAME2 pragma-inline, `pragma(inline)` was added:)
 
     $(P A new pragma was added for more fine-grained control of inlining.
@@ -276,6 +208,74 @@ $(LI $(LNAME2 invalid-cast-check, Invalid reinterpret casts can be detected in t
 )
 
 $(BUGSTITLE Library Changes,
+
+$(LI $(LNAME2 rangified-functions, Many phobos functions were rangified.)
+
+    $(P Many phobos functions that allocated GC memory were changed to support
+        ranges or were complemented by an alternative supporting ranges.
+        Using ranges often eliminates GC allocations.
+    )
+
+        ---
+        setExtension("foo.jpg", ".png"); // allocates a new string
+        withExtension("foo.jpg", ".png"); // returns a range without allocating
+        ---
+
+    $(BOOKTABLE Rangified Functions:,
+        $(TR $(TH Module) $(TH Functions)
+        )
+        $(TR $(TD $(STDMODREF algorithm_comparison, std.algorithm.comparison))
+            $(TD
+                $(XREF algorithm_comparison, levenshteinDistance)
+            )
+        )
+        $(TR $(TD $(STDMODREF path, std.path))
+            $(TD
+                $(XREF path, asAbsolutePath)
+                $(XREF path, asNormalizedPath)
+                $(XREF path, asRelativePath)
+                $(XREF path, chainPath)
+                $(XREF path, dirName)
+                $(XREF path, driveName)
+                $(XREF path, filenameCmp)
+                $(XREF path, globMatch)
+                $(XREF path, isValidFilename)
+                $(XREF path, isValidPath)
+                $(XREF path, pathSplitter)
+                $(XREF path, rootName)
+                $(XREF path, stripExtension)
+                $(XREF path, withDefaultExtension)
+                $(XREF path, withExtension)
+            )
+        )
+        $(TR $(TD $(STDMODREF string, std.string))
+            $(TD
+                $(XREF string, centerJustifier)
+                $(XREF string, chomp)
+                $(XREF string, chompPrefix)
+                $(XREF string, chop)
+                $(XREF string, column)
+                $(XREF string, detabber)
+                $(XREF string, entabber)
+                $(XREF string, indexOf)
+                $(XREF string, leftJustifier)
+                $(XREF string, makeTransTable)
+                $(XREF string, rightJustifier)
+                $(XREF string, soundexer)
+                $(XREF string, strip)
+                $(XREF string, stripLeft)
+                $(XREF string, stripRight)
+            )
+        )
+        $(TR $(TD $(STDMODREF uni, std.uni))
+            $(TD
+                $(XREF uni, asCapitalized)
+                $(XREF uni, asLowerCase)
+                $(XREF uni, asUpperCase)
+            )
+        )
+    )
+)
 
 $(LI $(LNAME2 gc-api-profile, GC API calls can now be profiled separately.)
 


### PR DESCRIPTION
The jump link is already in the proper section.