### PR TITLE
Issue 14963: XREF and XREF_PACKED_NAMED should use relative, not absolute, URLs

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -301,9 +301,9 @@ WIKI=$(TITLE)
 _=
 
 XREF=$(XREF2 $1, $2, $(D std.$1.$2))
-XREF2=$(SPANC libref, $(AHTTP dlang.org/phobos/std_$1.html#$2, $(TAIL $+)))
+XREF2=$(SPANC libref, $(A /phobos/std_$1.html#$2, $(TAIL $+)))
 XREF_PACK=$(XREF_PACK_NAMED $1, $2, $3, $(D std.$1.$2.$3))
-XREF_PACK_NAMED=$(SPANC libref, $(AHTTP dlang.org/phobos/std_$1_$2.html#$3, $4))
+XREF_PACK_NAMED=$(SPANC libref, $(A /phobos/std_$1_$2.html#$3, $4))
 _=
 
 YELLOW=$(SPANC yellow, $0)

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -301,9 +301,9 @@ WIKI=$(TITLE)
 _=
 
 XREF=$(XREF2 $1, $2, $(D std.$1.$2))
-XREF2=$(SPANC libref, $(A /phobos/std_$1.html#$2, $(TAIL $+)))
+XREF2=$(SPANC libref, $(A $(ROOT_DIR)phobos/std_$1.html#$2, $(TAIL $+)))
 XREF_PACK=$(XREF_PACK_NAMED $1, $2, $3, $(D std.$1.$2.$3))
-XREF_PACK_NAMED=$(SPANC libref, $(A /phobos/std_$1_$2.html#$3, $4))
+XREF_PACK_NAMED=$(SPANC libref, $(A $(ROOT_DIR)phobos/std_$1_$2.html#$3, $4))
 _=
 
 YELLOW=$(SPANC yellow, $0)

--- a/std.ddoc
+++ b/std.ddoc
@@ -37,3 +37,7 @@ JOIN_DOT_TAIL=$(JOIN_DOT $+)
 JOIN_DOT=.$1$(JOIN_DOT $+)
 TAIL=$+
 _=
+
+XREF2=$(SPANC libref, $(A std_$1.html#$2, $(TAIL $+)))
+XREF_PACK_NAMED=$(SPANC libref, $(A std_$1_$2.html#$3, $4))
+_=


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=14963

Using absolute URLs break the doc tester, local dlang.org installations, as well as cross-module links in `phobos-prerelease`, as it forces everything to point to `http://dlang.org/phobos/`.

This reverts the generated links back to relative URLs.