### PR TITLE
Issue 14972: Include std.windows modules in navbar.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -37,10 +37,10 @@ STABLE_RDMD=$(STABLE_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODE
 # exclude lists
 MOD_EXCLUDES_PRERELEASE=$(addprefix --ex=, gc. rt. core.internal. core.stdc.config core.sys.	\
 	std.c. std.algorithm.internal std.internal. std.regex.internal. std.typelist		\
-	std.windows. etc.linux.memoryerror std.stream std.cstream std.socketstream		\
-	std.metastrings std.experimental.ndslice.internal)
+	std.windows.iunknown std.windows.registry etc.linux.memoryerror std.stream std.cstream	\
+	std.socketstream std.metastrings std.experimental.ndslice.internal)
 
-MOD_EXCLUDES_RELEASE=$(MOD_EXCLUDES_PRERELEASE) --ex=core.stdc.
+MOD_EXCLUDES_RELEASE=$(MOD_EXCLUDES_PRERELEASE) $(addprefix --ex=, core.stdc. std.windows.)
 
 # rdmd must fetch the model, imports, and libs from the specified version
 DFLAGS=-m$(MODEL) -I$(DRUNTIME_DIR)/import -I$(PHOBOS_DIR) -L-L$(PHOBOS_DIR)/generated/$(OS)/release/$(MODEL)


### PR DESCRIPTION
This is a first stab at fixing: https://issues.dlang.org/show_bug.cgi?id=14972

This is probably a rather crude way of doing things, and I probably overlooked some issues this may cause, but it's just to get the ball rolling on making Windows-specific docs show up on dlang.org.

*Note:* Please also see the corresponding Phobos PR (https://github.com/D-Programming-Language/phobos/pull/3593) to actually generate docs for `std.windows.*`, otherwise this PR won't do very much.