### PR TITLE
add a search option for the changelog

### DIFF
--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -8,6 +8,9 @@ $(NDASH) $(A index.html, all versions))
 CHANGELOG_NAV_LAST=$(DIVC changelog-nav, previous version: $(A $1.html, $1)
 $(NDASH) $(A index.html, all versions))
 
+SEARCH_OPTIONS_EXTRA=<option value="dlang.org/changelog" selected>Change
+Log</option>
+
 VERSION=
 <div class="version">
 $(P

--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -256,10 +256,12 @@ SEARCH_BOX=
                     <option value="dlang.org">Entire D Site</option>
                     <option $(SEARCHDEFAULT_PHOBOS) value="dlang.org/phobos">Library Reference</option>
                     <option $(SEARCHDEFAULT_FORUM) value="forum.dlang.org">Discussion Forums</option>
+                    $(SEARCH_OPTIONS_EXTRA)
                 </select>
             )$(SPANID search-submit, <button type="submit"><i class="fa fa-search"></i><span>go</span></button>)
         </form>
     )
+SEARCH_OPTIONS_EXTRA=
 _=
 
 SECTION1=$(H1 $1)$+


### PR DESCRIPTION
It's only available on changelog pages. And there it's the default.