### PR TITLE
fix Issue 14808 - phobos sidebar "D Lib" link is back to homepage

### DIFF
--- a/std_navbar-prerelease.ddoc
+++ b/std_navbar-prerelease.ddoc
@@ -1,6 +1,6 @@
 NAVIGATION=
 $(DIVID cssmenu, $(UL
-    $(MENU ../index.html, D Lib Prerelease)
+    $(MENU index.html, D Lib Prerelease)
     $(MENU ../phobos/index.html, Current Release ($(LATEST)))
     $(MODULE_MENU)
     $(MENU http://code.dlang.org, 3rd Party Packages)

--- a/std_navbar-release.ddoc
+++ b/std_navbar-release.ddoc
@@ -1,6 +1,6 @@
 NAVIGATION=
 $(DIVID cssmenu, $(UL
-    $(MENU ../index.html, D Lib $(LATEST))
+    $(MENU index.html, D Lib $(LATEST))
     $(MENU ../phobos-prerelease/index.html, Prerelease Version)
     $(MODULE_MENU)
     $(MENU http://code.dlang.org, 3rd Party Packages)


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=14808