### PR TITLE
remove override of struct toHash and opEquals in example.

### DIFF
--- a/hash-map.dd
+++ b/hash-map.dd
@@ -125,7 +125,7 @@ $(H3 Using Structs or Unions as the KeyType)
         {
             string str;
 
-            override size_t $(CODE_HIGHLIGHT toHash)() const @safe pure nothrow
+            size_t $(CODE_HIGHLIGHT toHash)() const @safe pure nothrow
             {
                 size_t hash;
                 foreach (char c; str)
@@ -133,7 +133,7 @@ $(H3 Using Structs or Unions as the KeyType)
                 return hash;
             }
 
-            override bool $(CODE_HIGHLIGHT opEquals)(ref const MyString s) const @safe pure nothrow
+            bool $(CODE_HIGHLIGHT opEquals)(ref const MyString s) const @safe pure nothrow
             {
                 return std.string.cmp(this.str, s.str) == 0;
             }


### PR DESCRIPTION
The struct MyString example didn't compile because the methods were marked as override.