### PR TITLE
Document the ELFv1 and ELFv2 version identifiers.

### DIFF
--- a/version.dd
+++ b/version.dd
@@ -293,6 +293,8 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D Alpha_HardFloat)) , $(ARGS The Alpha hard float ABI))
 	$(TROW $(ARGS $(D LittleEndian)) , $(ARGS Byte order, least significant first))
 	$(TROW $(ARGS $(D BigEndian)) , $(ARGS Byte order, most significant first))
+	$(TROW $(ARGS $(D ELFv1)) , $(ARGS The Executable and Linkable Format v1))
+	$(TROW $(ARGS $(D ELFv2)) , $(ARGS The Executable and Linkable Format v2))
 	$(TROW $(ARGS $(D D_Coverage)) , $(ARGS $(DPLLINK code_coverage.html, Code coverage analysis) instrumentation (command line $(DDSUBLINK dmd-windows, switches, switch) $(D -cov)) is being generated))
 	$(TROW $(ARGS $(D D_Ddoc)) , $(ARGS $(DDLINK ddoc, Embedded Documentation, Ddoc) documentation (command line $(DDSUBLINK dmd-windows, switches, switch) $(D -D)) is being generated))
 	$(TROW $(ARGS $(D D_InlineAsm_X86)) , $(ARGS $(DDLINK iasm, Inline Assembler, Inline assembler) for X86 is implemented))


### PR DESCRIPTION
These identifiers are defined for some time but I did not update
the documentation.
ELFv1 is defined on most systems using ELF.
ELFv2 is defined on Linux/PPC64le.