### PR TITLE
Introduce SystemZ version identifier and deprecate S390X.

### DIFF
--- a/version.dd
+++ b/version.dd
@@ -279,7 +279,7 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(TROW $(ARGS $(D SPARC_HardFloat)) , $(ARGS The SPARC hard float ABI))
 	$(TROW $(ARGS $(D SPARC64)) , $(ARGS The SPARC architecture, 64-bit))
 	$(TROW $(ARGS $(D S390)) , $(ARGS The System/390 architecture, 32-bit))
-	$(TROW $(ARGS $(D S390X)) , $(ARGS The System/390X architecture, 64-bit))
+	$(TROW $(ARGS $(D SystemZ)) , $(ARGS The System Z architecture, 64-bit))
 	$(TROW $(ARGS $(D HPPA)) , $(ARGS The HP PA-RISC architecture, 32-bit))
 	$(TROW $(ARGS $(D HPPA64)) , $(ARGS The HP PA-RISC architecture, 64-bit))
 	$(TROW $(ARGS $(D SH)) , $(ARGS The SuperH architecture, 32-bit))
@@ -314,6 +314,7 @@ $(H3 $(LEGACY_LNAME2 PredefinedVersions, predefined-versions, Predefined Version
 	$(THEAD Version Identifier, Description)
 	$(TROW $(D darwin), The Darwin operating system; use $(D OSX) instead)
 	$(TROW $(D Thumb), ARM in Thumb mode; use $(D ARM_Thumb) instead)
+	$(TROW $(D S390X), The System/390X architecture, 64-bit; use $(D SystemZ) instead)
 	)
 
 	$(P Others will be added as they make sense and new implementations appear.


### PR DESCRIPTION
The new 64-bit architecture is called System z. IMHO we should
use this name instead the cryptic S390X.