### PR TITLE
Update the version of Windows that we support.

### DIFF
--- a/dcompiler.dd
+++ b/dcompiler.dd
@@ -38,7 +38,7 @@ $(H2 $(LNAME2 requirements, Requirements and Downloads))
 	$(LI $(LINK2 http://dlang.org/download.html, Download D Compiler))
 
     $(WINDOWS
-	$(LI Windows operating system, Windows XP or later, 32 or 64 bit)
+	$(LI Windows operating system, Windows 7 or later, 32 or 64 bit)
 
 	$(LI Download
 	 <a href="http://ftp.digitalmars.com/dmc.zip" title="download dmc.zip">


### PR DESCRIPTION
It was decided even before XP went EOL that we're not going to
officially support it anymore. It was decided that we officially support
Windows 7 and later, but the download page was not updated, and it still
says XP.

http://forum.dlang.org/post/ktfgps$2ghh$1@digitalmars.com

So, this fixes it so that it says Windows 7.

This just came up in D.Learn, and folks are giving the incorrect answer thanks to the current state of the download page: http://forum.dlang.org/post/uxqojxjkuarkaowpyrzz@forum.dlang.org