### PR TITLE
fix COREMODREF

### DIFF
--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -42,7 +42,7 @@ DRUNTIMEBUGSFIXED2=$(LINK2 https://issues.dlang.org/buglist.cgi?chfieldto=$2&que
 PHOBOSBUGSFIXED2=$(LINK2 https://issues.dlang.org/buglist.cgi?chfieldto=$2&query_format=advanced&chfield=resolution&chfieldfrom=$1&chfieldvalue=FIXED&bug_severity=regression&bug_severity=blocker&bug_severity=critical&bug_severity=major&bug_severity=normal&bug_severity=minor&bug_severity=trivial&bug_status=RESOLVED&version=D2&version=D1%20%26%20D2&component=Phobos&resolution=FIXED&product=D, Phobos Bugs Fixed)
 
 STDMODREF = <a href="$(ROOT_DIR)phobos/std_$1.html">$(D $2)</a>
-COREMODREF = <a href="phobos/core_$1.html">$(D $2)</a>
+COREMODREF = <a href="$(ROOT_DIR)phobos/core_$1.html">$(D $2)</a>
 XREF = <a href="$(ROOT_DIR)phobos/std_$1.html#$2">$(D $2)</a>
 CXREF = <a href="$(ROOT_DIR)phobos/core_$1.html#$2">$(D $2)</a>
 


### PR DESCRIPTION
This fixes the link to core.runtime on <http://dlang.org/changelog/2.068.1.html>.