### PR TITLE
changelog 2.069.0

### DIFF
--- a/changelog/2.069.0_pre.dd
+++ b/changelog/2.069.0_pre.dd
@@ -149,7 +149,7 @@ $(LI $(LNAME2 std-algorithm-moveEmplace, A combined `moveEmplace` was added.)
     )
 )
 
-$(LI $(RELATIVE_LINK2 curl-dynamic-loading, libcurl is now loaded dynamically)
+$(LI $(LNAME2 curl-dynamic-loading, libcurl is now loaded dynamically)
 
     $(P $(STDMODREF net_curl, std.net.curl) was changed to load curl as shared
         library at runtime.  This simplifies the usage as it's no longer

--- a/changelog/2.069.0_pre.dd
+++ b/changelog/2.069.0_pre.dd
@@ -5,6 +5,7 @@ $(CHANGELOG_NAV_LAST 2.068.2)
 $(VERSION Oct 18, 2015, =================================================,
 
 $(BUGSTITLE Compiler Changes,
+$(LI $(RELATIVE_LINK2 self-hosted-dmd, DMD has been ported to D.))
 $(LI $(RELATIVE_LINK2 objective-c-support, Basic support for Objective-C.))
 $(LI $(RELATIVE_LINK2 property-switch-deprecated, The $(TT -property) switch has
     been deprecated.))
@@ -30,6 +31,14 @@ $(BR)$(BIG $(RELATIVE_LINK2 bugfix-list, List of all bug fixes and enhancements 
 $(HR)
 
 $(BUGSTITLE Compiler Changes,
+
+$(LI $(LNAME2 self-hosted-dmd, DMD has been ported to D.)
+
+    $(P The DMD frontend code has been ported to D.  Self-hosting the
+        compiler allows us to benefit from D's improved productivity
+        and modelling power.
+    )
+)
 
 $(LI $(LNAME2 objective-c-support, Basic support for Objective-C.)
 

--- a/changelog/2.069.0_pre.dd
+++ b/changelog/2.069.0_pre.dd
@@ -2,7 +2,7 @@ Ddoc
 
 $(CHANGELOG_NAV_LAST 2.068.2)
 
-$(BETA_VERSION Oct 18, 2015, =================================================,
+$(VERSION Oct 18, 2015, =================================================,
 
 $(BUGSTITLE Compiler Changes,
 $(LI $(RELATIVE_LINK2 objective-c-support, Basic support for Objective-C.))

--- a/changelog/changelog.ddoc
+++ b/changelog/changelog.ddoc
@@ -20,15 +20,6 @@ $(SMALL released $1, $2)
 $4
 )
 
-BETA_VERSION=
-$(DIVC version,
-$(P
-$(B $(LARGE $(LINK2 http://downloads.dlang.org/pre-releases/2.x/$(VER), Download D $(VER) Beta)))$(BR)
-$(SMALL to be released $1, $2)
-)
-$4
-)
-
 BUGZILLA = <a href="https://issues.dlang.org/show_bug.cgi?id=$0">Bugzilla $0</a>
 CPPBUGZILLA = <a href="http://bugzilla.digitalmars.com/issues/show_bug.cgi?id=$0">Bugzilla $0</a>
 DSTRESS = dstress $0

--- a/changelog/prerelease.ddoc
+++ b/changelog/prerelease.ddoc
@@ -1,0 +1,13 @@
+VERSION=
+$(DIVC version,
+$(P
+$(B $(LARGE $(LINK2 http://downloads.dlang.org/pre-releases/2.x/$(VER), Download D $(VER) Beta)))$(BR)
+$(SMALL to be released $1, $2)
+)
+$4
+)
+
+STDMODREF = <a href="$(ROOT_DIR)phobos-prerelease/std_$1.html">$(D $2)</a>
+COREMODREF = <a href="$(ROOT_DIR)phobos-prerelease/core_$1.html">$(D $2)</a>
+XREF = <a href="$(ROOT_DIR)phobos-prerelease/std_$1.html#$2">$(D $2)</a>
+CXREF = <a href="$(ROOT_DIR)phobos-prerelease/core_$1.html#$2">$(D $2)</a>

--- a/posix.mak
+++ b/posix.mak
@@ -115,6 +115,7 @@ DDOC=$(addsuffix .ddoc, macros html dlang.org doc ${GENERATED}/${LATEST}) $(NODA
 STD_DDOC=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-release ${GENERATED}/modlist-${LATEST}) $(NODATETIME)
 STD_DDOC_PRE=$(addsuffix .ddoc, macros html dlang.org ${GENERATED}/${LATEST} std std_navbar-prerelease ${GENERATED}/modlist-prerelease) $(NODATETIME)
 CHANGELOG_DDOC=${DDOC} changelog/changelog.ddoc $(NODATETIME)
+CHANGELOG_PRE_DDOC=${CHANGELOG_DDOC} changelog/prerelease.ddoc
 
 IMAGES=favicon.ico $(addprefix images/, \
 	d002.ico \
@@ -153,7 +154,7 @@ SPEC_ROOT=spec intro lex grammar module declaration type property attribute prag
 	simd
 SPEC_DD=$(addsuffix .dd,$(SPEC_ROOT))
 
-CHANGELOG_FILES=$(shell ls changelog/*.dd | sed s/\\.dd$$// )
+CHANGELOG_FILES=$(basename $(subst _pre.dd,.dd,$(wildcard changelog/*.dd)))
 
 # Website root filenames. They have extension .dd in the source
 # and .html in the generated HTML. Save for the expansion of
@@ -181,10 +182,16 @@ ALL_FILES = $(ALL_FILES_BUT_SITEMAP) $(DOC_OUTPUT_DIR)/sitemap.html
 $(DOC_OUTPUT_DIR)/changelog/%.html : changelog/%.dd $(CHANGELOG_DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(CHANGELOG_DDOC) $<
 
+$(DOC_OUTPUT_DIR)/changelog/%.html : changelog/%_pre.dd $(CHANGELOG_PRE_DDOC) $(DMD)
+	$(DMD) -conf= -c -o- -Df$@ $(CHANGELOG_PRE_DDOC) $<
+
 $(DOC_OUTPUT_DIR)/%.html : %.dd $(DDOC) $(DMD)
 	$(DMD) -conf= -c -o- -Df$@ $(DDOC) $<
 
 $(DOC_OUTPUT_DIR)/%.verbatim : %.dd verbatim.ddoc $(DMD)
+	$(DMD) -c -o- -Df$@ verbatim.ddoc $<
+
+$(DOC_OUTPUT_DIR)/%.verbatim : %_pre.dd verbatim.ddoc $(DMD)
 	$(DMD) -c -o- -Df$@ verbatim.ddoc $<
 
 $(DOC_OUTPUT_DIR)/%.php : %.php.dd $(DDOC) $(DMD)

--- a/win32.mak
+++ b/win32.mak
@@ -60,6 +60,7 @@ DDOC=macros.ddoc html.ddoc dlang.org.ddoc windows.ddoc doc.ddoc $(NODATETIME)
 DDOC_STD=std.ddoc std_navbar-release.ddoc modlist-release.ddoc
 
 CHANGELOG_DDOC=$(DDOC) changelog/changelog.ddoc
+CHANGELOG_PRE_DDOC=$(CHANGELOG_DDOC) changelog/prerelease.ddoc
 
 ASSETS=images\*.* css\*.*
 IMG=dmlogo.gif cpp1.gif d002.ico c1.gif d3.png d4.gif d5.gif favicon.gif
@@ -306,8 +307,8 @@ changelog\2.068.1.html : $(CHANGELOG_DDOC) changelog\2.068.1.dd
 	$(DMD) -o- -c -D -Df$*.html $(CHANGELOG_DDOC) $*.dd
 changelog\2.068.2.html : $(CHANGELOG_DDOC) changelog\2.068.2.dd
 	$(DMD) -o- -c -D -Df$*.html $(CHANGELOG_DDOC) $*.dd
-changelog\2.069.0.html : $(CHANGELOG_DDOC) changelog\2.069.0.dd
-	$(DMD) -o- -c -D -Df$*.html $(CHANGELOG_DDOC) $*.dd
+changelog\2.069.0.html : $(CHANGELOG_DDOC) changelog\2.069.0_pre.dd
+	$(DMD) -o- -c -D -Df$*.html $(CHANGELOG_PRE_DDOC) $*.dd
 changelog\index.html : $(CHANGELOG_DDOC) changelog\index.dd
 	$(DMD) -o- -c -D -Df$*.html $(CHANGELOG_DDOC) $*.dd
 changelog\upcoming.html : $(CHANGELOG_DDOC) changelog\upcoming.dd


### PR DESCRIPTION
- fix links in pre-release changelog
- fix curl anchor
- add note about self-hosted ddmd