### PR TITLE
[2.069] mention @property in the changelog

### DIFF
--- a/changelog/2.069.0_pre.dd
+++ b/changelog/2.069.0_pre.dd
@@ -70,6 +70,11 @@ $(LI $(LNAME2 property-switch-deprecated, The $(TT -property) switch has
     $(P Since the behaviour of the $(TT -property) switch was not well-liked,
         it's been deprecated and made to have no effect when used.
     )
+
+    $(P The $(A $(ROOT_DIR)function.html#property-functions,$(D @property)
+        attribute) is not affected, and remains as a mostly cosmetic keyword.
+        Its semantics are going to be revisited in the future.
+    )
 )
 
 $(LI $(LNAME2 backend-improvements, DMD's codegen has improved.)

--- a/function.dd
+++ b/function.dd
@@ -371,7 +371,8 @@ $(H4 $(LNAME2 property-functions, Property Functions))
 
         $(P Property functions are tagged with the $(D @property)
         attribute. They cannot be called with parentheses (hence
-        they act like fields except in some cases).
+        they act like fields except in some cases) ($(B note:) dmd does not
+        enforce this currently).
         )
 
         $(P If a property function has no parameters, it works as a getter.


### PR DESCRIPTION
Also put a note on the spec page stating that @property is not implemented
and that its details may change.

I'm targetting the stable branch here. Is that right? Do we do that with the dlang.org repository?