### PR TITLE
Remove dpl-docs build workarounds on Windows.

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -553,10 +553,7 @@ apidocs-serve: docs.json
 docs.json:
 	mkdir .tmp
 	dir /s /b /a-d ..\druntime\src\*.d | findstr /V "unittest.d gcstub" > .tmp/files.txt
-	dir /s /b /a-d ..\phobos\*.d | findstr /V "unittest.d linux osx format.d" >> .tmp/files.txt
+	dir /s /b /a-d ..\phobos\*.d | findstr /V "unittest.d linux osx" >> .tmp/files.txt
 	dmd -c -o- -version=CoreDdoc -version=StdDdoc -Df.tmp/dummy.html -Xfdocs.json @.tmp/files.txt
-	# WORKAROUND FOR DEPENDECY TRACKING BUG IN DUB (issue #331)
-	dub build --nodeps --force --root $(DPL_DOCS_PATH)
-	#
 	$(DPL_DOCS) filter docs.json --min-protection=Protected --only-documented $(MOD_EXCLUDES_RELEASE)
 	rmdir /s /q .tmp


### PR DESCRIPTION
- Removes excluding format.d which used to fail compilation, but works now
- Removes the workaround for D-Programming-Language/dub#331, which has been fixed for a few releases now