### PR TITLE
Fix some typos

### DIFF
--- a/objc_interface.dd
+++ b/objc_interface.dd
@@ -60,8 +60,8 @@ $(SPEC_S Interfacing to Objective-C,
     )
 
     $(P
-        Selectors in Objective-C can contain characters that are not valid in D
-        identifiers, `:`. D supports method overloading while Objective-C
+        Selectors in Objective-C can contain the colon character, which is not valid in D
+        identifiers. D supports method overloading while Objective-C
         achieves something similar by using different selectors. For these two
         reasons it is better to be able to specify the selectors manually in D,
         instead of trying to infer it. This allows to have a more natural names
@@ -102,12 +102,12 @@ $(SPEC_S Interfacing to Objective-C,
 
     $(UL
         $(LI
-            The attribue can only be attached to methods with Objective-C
+            The attribute can only be attached to methods with Objective-C
             linkage
         )
 
-        $(LI The attribue can only be attached once to a method)
-        $(LI The attribue cannot be attached to a template method)
+        $(LI The attribute can only be attached once to a method)
+        $(LI The attribute cannot be attached to a template method)
 
         $(LI
             The number of colons in the selector needs to match the number of


### PR DESCRIPTION
Also, there was a statement that some "characters" were not valid symbol characters, but then listed only one character, the colon. The way this looked in the docs was very confusing (I wasn't sure if there was something missing after the colon).