### PR TITLE
one-click download button

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -72,7 +72,10 @@ $(COMMON_HEADERS_DLANG)
 $(EXTRA_HEADERS)
 </head>
 <body id='$(TITLE)' class='$(BODYCLASS)'>
-$(SCRIPT document.body.className += ' have-javascript')
+$(SCRIPT
+    document.body.className += ' have-javascript';
+    var LATEST = "$(LATEST)";
+)
 $(DIVID top,
 	$(DIVID header,
 		<img src="$(STATIC images/hamburger.svg)" id="mobile-hamburger">
@@ -203,8 +206,6 @@ NG_digitalmars_D_announce = <a href="$(NEWS digitalmars.D.announce,$0)">D.announ
 NOTRANSLATE=$(SPANC notranslate, $0)
 NO=
 NOT_EBOOK=$0
-NOTICE_L=<a href="$1" class="notice">$2</a>
-NOTICE=<span class="notice">$1</span>
 _=
 
 OPT=$(SUBSCRIPT opt)

--- a/index.dd
+++ b/index.dd
@@ -4,7 +4,7 @@ $(D_S D Programming Language,
 
 $(SECTION1 The D Programming Language$(BR) $(SPANC slogan, Modern convenience. Modeling power. Native efficiency.),
 
-$(NOTICE DMD $(LATEST) Released$(BR)<a href="download.html">Download</a> &middot; <a href="changelog/$(LATEST).html">Changelog</a>)
+$(NOTICE download, DMD $(LATEST) Released$(BR)<a href="download.html" class="download">Download</a> &middot; <a href="changelog/$(LATEST).html">Changelog</a>)
 $(TABLEC notice-table, $(TR $(TD
 $(WEB arsdnet.net/this-week-in-d/, This Week in D)
 )$(TD)$(TD
@@ -653,5 +653,9 @@ Macros:
     LAYOUT_SUFFIX=
     $(SCRIPTLOAD $(ROOT_DIR)js/run-main-website.js)
     $(SCRIPTLOAD http://arsdnet.net/this-week-in-d/twid-latest.js)
+    $(SCRIPTLOAD $(ROOT_DIR)js/one-click-download.js)
     LAYOUT_TITLE=
+    _=
+    NOTICE_L=<a href="$1" class="notice">$2</a>
+    NOTICE=<span class="notice $1">$2</span>
     _=

--- a/js/one-click-download.js
+++ b/js/one-click-download.js
@@ -1,0 +1,102 @@
+(function() {
+    var platform = navigator.platform.toLowerCase();
+
+    var Arch = {unknown: "unknown", x86: "x86", x86_64: "x86_64"};
+        // poor man's enum
+    var arch = Arch.unknown;
+    if (platform.match('x86_64|amd64'))
+    {
+        arch = Arch.x86_64;
+    }
+    else if (platform.match('i.86'))
+    {
+        arch = Arch.x86;
+    }
+
+    var name = '';
+    var file = '';
+
+    if (platform.match('win'))
+    {
+        name = 'Windows';
+        file = 'dmd-' + LATEST + '.exe';
+    }
+    else if (platform.match('mac'))
+    {
+        name = 'OS X';
+        file = 'dmd.' + LATEST + '.dmg';
+    }
+    else if (platform.match('linux'))
+    {
+        name = 'Linux';
+        file = 'dmd.' + LATEST + '.linux.tar.xz';
+
+        // See if the linux distribution is one for which we have a special package.
+        var ua = navigator.userAgent.toLowerCase();
+        if (ua.match('ubuntu|debian'))
+        {
+            if (arch === Arch.x86)
+            {
+                name = 'Ubuntu/Debian i386';
+                file = 'dmd_' + LATEST + '-0_i386.deb';
+            }
+            else if (arch == Arch.x86_64)
+            {
+                name = 'Ubuntu/Debian x86_64';
+                file = 'dmd_' + LATEST + '-0_amd64.deb';
+            }
+        }
+        else if (ua.match('fedora|centos'))
+        {
+            if (arch === Arch.x86)
+            {
+                name = 'Fedora/CentOS i386';
+                file = 'dmd-' + LATEST + '-0.fedora.i386.rpm';
+            }
+            else if (arch == Arch.x86_64)
+            {
+                name = 'Fedora/CentOS x86_64';
+                file = 'dmd-' + LATEST + '-0.fedora.x86_64.rpm';
+            }
+        }
+        else if (ua.match('suse'))
+        {
+            if (arch === Arch.x86)
+            {
+                name = 'openSUSE i386';
+                file = 'dmd-' + LATEST + '-0.openSUSE.i386.rpm';
+            }
+            else if (arch == Arch.x86_64)
+            {
+                name = 'openSUSE x86_64';
+                file = 'dmd-' + LATEST + '-0.openSUSE.x86_64.rpm';
+            }
+        }
+    }
+    else if (platform.match('freebsd'))
+    {
+        if (arch === Arch.x86)
+        {
+            name = 'FreeBSD i386';
+            file = 'dmd.' + LATEST + '.freebsd-32.tar.xz';
+        }
+        else if (arch == Arch.x86_64)
+        {
+            name = 'FreeBSD x86_64';
+            file = 'dmd.' + LATEST + '.freebsd-64.tar.xz';
+        }
+    }
+
+    if (file !== "")
+    {
+        var url = 'http://downloads.dlang.org/releases/2.x/' + LATEST  + '/' +
+            file;
+        $('.notice.download a.download').attr('href', url);
+        $('.notice.download a.download').append(' for ' + name);
+        $('.notice.download')
+            .append(' &middot; ')
+            .append($('<a>')
+                .attr('href', 'download.html')
+                .text('Other Downloads'));
+    }
+})();

--- a/posix.mak
+++ b/posix.mak
@@ -132,7 +132,8 @@ IMAGES=favicon.ico $(addprefix images/, \
 	$(addsuffix .jpg, tdpl))
 
 JAVASCRIPT=$(addsuffix .js, $(addprefix js/, \
-	codemirror-compressed dlang ddox listanchors run run-main-website jquery-1.7.2.min))
+	codemirror-compressed dlang ddox listanchors one-click-download run \
+	run-main-website jquery-1.7.2.min))
 
 STYLES=$(addsuffix .css, $(addprefix css/, \
 	style print codemirror ddox cssmenu))


### PR DESCRIPTION
![snapshot1](https://cloud.githubusercontent.com/assets/9287500/11069036/8aab3d8a-87d4-11e5-8c3d-ab888d875a61.png)

(To avoid confusion, it looked [like this](https://cloud.githubusercontent.com/assets/9287500/10711239/4fb76968-7a75-11e5-8677-8a27eebdc952.png) before [this point in the discussion](https://github.com/D-Programming-Language/dlang.org/pull/1139#issuecomment-155489317).)

I've only tested a couple browser/OS combinations:
Windows 7: Internet Explorer, Firefox and Chrome all get it right (.exe download).
Ubuntu 15.10: Firefox gets it right (.deb download), Chrome and Konqueror only get Linux (.tar.xz download).

I'm not sure if going for the generic Linux download is the right thing to do when no specific distribution could be detected. It may be better to lead people to download.html where they may find a proper package.

Would be nice if someone could test OS X, Debian, Fedora, CentOS, openSUSE, and FreeBSD.

~~The first commit fixes a couple issues with the current notices. See the commit message for details.~~ (Maybe later.)