### PR TITLE
arrays.dd: clarify intended meaning of reserve function and append operator with example

### DIFF
--- a/arrays.dd
+++ b/arrays.dd
@@ -549,7 +549,7 @@ a[15] = 'z';   // does not affect c, because either a or c has reallocated.
 
 
         $(P To guarantee copying behavior, use the .dup property to ensure
-        a unique array that can be resized. Also, one may use the phobos
+        a unique array that can be resized. Also, one may use the
         $(D .capacity) property to determine how many elements can be appended
         to the array without reallocating.
         )
@@ -600,8 +600,16 @@ array.length = i;
         input from the console - it's unlikely to be longer than 80.
         )
 
-        $(P Also, you may wish to utilize the phobos $(D reserve)
+        $(P Also, you may wish to utilize the $(D reserve)
         function to pre-allocate array data to use with the append operator.)
+
+---------
+int[] array;
+size_t cap = array.reserve(10); // request
+array ~= [1, 2, 3, 4, 5];
+assert(cap >= 10); // allocated may be more than request
+assert(cap == array.capacity);
+---------
 
 $(H3 $(LNAME2 func-as-property, Functions as Array Properties))
 


### PR DESCRIPTION
I removed the two occurrences of Phobos since the relevant property/function is actually in druntime.