### PR TITLE
Issue 12421 - Allow simpler syntax for lambda template declarations

### DIFF
--- a/changelog/2.069.0_pre.dd
+++ b/changelog/2.069.0_pre.dd
@@ -12,6 +12,10 @@ $(LI $(RELATIVE_LINK2 property-switch-deprecated, The $(TT -property) switch has
 $(LI $(RELATIVE_LINK2 backend-improvements, DMD's codegen has improved.))
 )
 
+$(BUGSTITLE Language Changes,
+$(LI $(RELATIVE_LINK2 alias-funclit, Add syntactic support to make an alias to a function literal.))
+)
+
 $(BUGSTITLE Library Changes,
 $(LI The package $(STDMODREF experimental_allocator, std.experimental.allocator) was added.)
 $(LI $(RELATIVE_LINK2 more-rangified-functions, More phobos functions were rangified.))
@@ -88,6 +92,24 @@ $(LI $(LNAME2 backend-improvements, DMD's codegen has improved.)
     )
 )
 
+)
+
+$(BUGSTITLE Language Changes,
+$(LI $(LNAME2 alias-funclit, Add syntactic support to make an alias to a function literal.)
+
+    $(P Example:)
+
+        ---
+        alias less1 = (a, b) => a < b;
+        alias less2 = (a, b) => a > b;
+
+        import std.algorithm : sort, equal;
+
+        int[] arr = [4, 1, 3, 2];
+        assert(equal(sort!less1(arr), [1, 2, 3, 4]));
+        assert(equal(sort!less2(arr), [4, 3, 2, 1]));
+        ---
+)
 )
 
 $(BUGSTITLE Library Changes,

--- a/declaration.dd
+++ b/declaration.dd
@@ -334,6 +334,7 @@ $(GNAME AliasDeclarationX):
 
 $(GNAME AliasDeclarationY):
     $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
+    $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK2 expression, FunctionLiteral)
 )
 
     $(P $(I AliasDeclaration)s create a symbol that is an alias for another type,

--- a/declaration.dd
+++ b/declaration.dd
@@ -280,8 +280,11 @@ $(GNAME AutoDeclaration):
     $(GLINK StorageClasses) $(I AutoDeclarationX) $(D ;)
 
 $(GNAME AutoDeclarationX):
+    $(GLINK AutoDeclarationY)
+    $(I AutoDeclarationX) $(D ,) $(GLINK AutoDeclarationY)
+
+$(GNAME AutoDeclarationY):
     $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
-    $(I AutoDeclarationX) $(D ,) $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
 )
 
         $(P If a declaration starts with a $(I StorageClass) and has
@@ -326,8 +329,11 @@ $(GNAME AliasDeclaration):
     $(D alias) $(I AliasDeclarationX) $(D ;)
 
 $(GNAME AliasDeclarationX):
+    $(GLINK AliasDeclarationY)
+    $(I AliasDeclarationX) $(D ,) $(GLINK AliasDeclarationY)
+
+$(GNAME AliasDeclarationY):
     $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
-    $(I AliasDeclarationX) $(D ,) $(I Identifier) $(GLINK2 template, TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
 )
 
     $(P $(I AliasDeclaration)s create a symbol that is an alias for another type,

--- a/grammar.dd
+++ b/grammar.dd
@@ -1013,8 +1013,11 @@ $(GNAME AliasDeclaration):
     $(D alias) $(I AliasDeclarationX) $(D ;)
 
 $(GNAME AliasDeclarationX):
+    $(GLINK AliasDeclarationY)
+    $(I AliasDeclarationX) $(D ,) $(GLINK AliasDeclarationY)
+
+$(GNAME AliasDeclarationY):
     $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
-    $(I AliasDeclarationX) $(D ,) $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
 )
 
 $(GRAMMAR
@@ -1022,8 +1025,11 @@ $(GNAME AutoDeclaration):
     $(GLINK StorageClasses) $(I AutoDeclarationX) $(D ;)
 
 $(GNAME AutoDeclarationX):
+    $(GLINK AutoDeclarationY)
+    $(I AutoDeclarationX) $(D ,) $(GLINK AutoDeclarationY)
+
+$(GNAME AutoDeclarationY):
     $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
-    $(I AutoDeclarationX) $(D ,) $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK Initializer)
 )
 
 $(GRAMMAR

--- a/grammar.dd
+++ b/grammar.dd
@@ -1018,6 +1018,7 @@ $(GNAME AliasDeclarationX):
 
 $(GNAME AliasDeclarationY):
     $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK StorageClasses)$(OPT) $(GLINK Type)
+    $(I Identifier) $(GLINK TemplateParameters)$(OPT) $(D =) $(GLINK FunctionLiteral)
 )
 
 $(GRAMMAR


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12421

Corresponding compiler change: D-Programming-Language/dmd#3638