### PR TITLE
Fix small bug in lazy-evalution.dd

### DIFF
--- a/lazy-evaluation.dd
+++ b/lazy-evaluation.dd
@@ -174,7 +174,7 @@ $(P It can be used like:
 void foo()
 {
     int x = 0;
-    dotimes(10, writeln(x++));
+    dotimes(10, write(x++));
 }
 ---
 


### PR DESCRIPTION
Fix a small bug in a code example, so that the code matches with the given console output.