### PR TITLE
Left Align Text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -801,8 +801,18 @@ div#content
     background-color: #f6f6f6;
     font-size: 0.875em;
     line-height: 1.4em;
-    text-align: justify;
     border: 0.25em solid #ccd5d5;
+}
+
+/*  This is a CSS hack to only target Blink based browsers
+    Targets Chrome 28 and later and Opera 14 and later
+*/
+@media all and (-webkit-min-device-pixel-ratio:0) and (min-resolution: .001dpcm) {
+    div#content
+    {
+        /* because Blink based browsers don't support hyphens */
+        text-align: left;
+    }
 }
 
 body#Home div#content


### PR DESCRIPTION
I know that discussing styling decisions on the internet is a road full of personal opinion and flame wars, so I want to keep this discussion purely practical by stating this: justified text is harder to read on the web than left aligned text.

A good summary of the problems and the evidence behind them can be found here: https://kaiweber.wordpress.com/2010/05/31/ragged-right-or-justified-alignment/. TL;DR is that it makes little difference for people who can read well, but for people with dyslexia or other reading disabilities, justified text is much harder for them to comprehend.

Also, the reason that most books are justified is they are done by hand or reviewed and edited by someone after a automatic process is finished. Automatic justifying software is just not up to the task in most cases, creating lots of weird hyphenations, off line breaks, and rivers in text, e.g. https://en.wikipedia.org/wiki/River_(typography)#/media/File:Typographic_river.svg 

For some less scientific evidence, if you look on the web at sites that are purely designed to have a good reading experience for long form content, Medium, Feedly, Pocket, Instapaper, Readability, and Safari's built-in Reader View, they all use left aligned text.