### PR TITLE
Remove wc example from Books & Articles submenu

### DIFF
--- a/doc.ddoc
+++ b/doc.ddoc
@@ -86,7 +86,6 @@ $(DIVID cssmenu, $(UL
         $(ROOT_DIR)const-faq.html, const(FAQ),
         $(ROOT_DIR)comparison.html, Feature Overview,
         $(ROOT_DIR)d-floating-point.html, Floating Point,
-        $(ROOT_DIR)wc.html, Example: wc,
         $(ROOT_DIR)warnings.html, Warnings,
         $(ROOT_DIR)rationale.html, Rationale,
         $(ROOT_DIR)builtin.html, Builtin Rationale,


### PR DESCRIPTION
It doesn't fit there and I don't understand why that example is in the menus at all. wc.dd is still there, so a link can be added elsewhere if desired.