### PR TITLE
set ROOT_DIR=/ for DDox pages

### DIFF
--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -4,4 +4,5 @@ XREF_PACK = std.$1.$2.$3
 CXREF = core.$1.$2
 ECXREF = etc.$1.$2
 LREF = $1
+ROOT_DIR=/
 _=


### PR DESCRIPTION
DDox generates a nested directory structure, so a relative ROOT_DIR, as is
used for /phobos/ pages, doesn't work.

This fixes links on http://dlang.org, but not in local mirrors (releases,
git clones). There it actually even breaks some links that happened to
work before.