### PR TITLE
bugstats.php.dd: Add hidden iframe to trigger generating the image

### DIFF
--- a/bugstats.php.dd
+++ b/bugstats.php.dd
@@ -36,7 +36,10 @@ $(DISPLAY All open, y_axis_field=bug_severity&amp;query_format=report-table&amp;
 $(DISPLAY All closed, y_axis_field=bug_severity&amp;query_format=report-table&amp;product=D&amp;bug_severity=normal&amp;bug_severity=minor&amp;bug_severity=trivial&amp;bug_severity=regression&amp;bug_severity=blocker&amp;bug_severity=critical&amp;bug_severity=major&amp;bug_severity=enhancement&amp;bug_status=RESOLVED&amp;bug_status=VERIFIED&amp;bug_status=CLOSED)
 )
 
-$(P <center>$(LINK2 https://issues.dlang.org/reports.cgi?product=D&amp;datasets=NEW&amp;datasets=ASSIGNED&amp;datasets=REOPENED&amp;datasets=RESOLVED, <img border="1" src="https://issues.dlang.org/graphs/mVH75HpydPklNqy3BSv8EvqlAOaP1WacmgYB1CsRbiM.png">)</center>)
+<!-- hidden iframe to graph HTML URL, to trigger generating the image linked to below -->
+<iframe width="1" height="1" frameBorder="0" src="$(GRAPH_HTML_URL)"></iframe>
+
+$(P <center>$(LINK2 $(GRAPH_HTML_URL), <img border="1" src="$(GRAPH_IMG_URL)">)</center>)
 
 )
 
@@ -45,4 +48,6 @@ Macros:
   PHP=<?php $0 ?>
   BOOKTABLE = <center><table cellspacing="0" cellpadding="5" class="book"><caption>$1</caption>$2</table></center>
   DISPLAY=$(TR $(TD $(LINK2 https://issues.dlang.org/buglist.cgi?$2, $1)) $(TD <iframe scrolling="no" frameborder="0" width="4.8em" height="1.4em" style="width:4.8em;height:1.4em;" vspace="0" hspace="0" marginwidth="0" marginheight="0" src="fetch-issue-cnt.php?$2&amp;format=table&amp;action=wrap&amp;ctype=csv"></iframe>))
+  GRAPH_HTML_URL=https://issues.dlang.org/reports.cgi?product=D&amp;datasets=NEW&amp;datasets=ASSIGNED&amp;datasets=REOPENED&amp;datasets=RESOLVED
+  GRAPH_IMG_URL=https://issues.dlang.org/graphs/mVH75HpydPklNqy3BSv8EvqlAOaP1WacmgYB1CsRbiM.png
   WIKI=BugStats


### PR DESCRIPTION
I've regularly noticed that the graph image linked to from bugstats.php
would not display - however, it would start displaying for a while when
you visit the page it links to. Since the image URL seems to link to a
static file, I guess that the graphs are generated by the CGI request,
and the static files are cleaned up periodically. Thus, to have the image
display on another website (dlang.org), we also need to regularly trigger
its generation, one way being to make the CGI request to generate the
image at the same time as when requesting the image.