### PR TITLE
Fix crash in index sample code

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -40,17 +40,12 @@ static reFloatingPoint = ctRegex!`[0-9]+\.[0-9]+`;
 
 void main(string[] args)
 {
-    // If arguments, process those and exit,
-    // otherwise wait around for input on stdin
-    if (args.length > 1)
-        args[1..$].map!round.joiner(" ").writeln;
-    else
-        // Replace anything that looks like a real
-        // number with the rounded equivalent.
-        stdin.byLine(KeepTerminator.yes)
-             .map!(l => l.replaceAll!(c => c.hit.round)
-                                     (reFloatingPoint))
-             .copy(stdout.lockingTextWriter());
+    // Replace anything that looks like a real
+	// number with the rounded equivalent.
+	stdin.byLine(KeepTerminator.yes)
+		.map!(l => l.replaceAll!(c => c.hit.round)
+			  (reFloatingPoint))
+		.copy(stdout.lockingTextWriter());
 }
 ----
 )


### PR DESCRIPTION
The example on dlang.org's index page which rounds floats currently crashes when ran. If you dump out `args` you can see that for some reason it's getting an empty string as `arg[1]`: `["./f347", ""]`

To "fix" this, I just removed support for reading from args.

```
std.conv.ConvException@/opt/compilers/dmd2/include/std/conv.d(2402): Floating point conversion error for input "".
----------------
??:? pure @safe bool std.exception.enforce!(bool).enforce(bool, lazy object.Throwable) [0x4b57ee]
??:? pure @safe real std.conv.parse!(real, immutable(char)[]).parse(ref immutable(char)[]) [0x4c8eee]
??:? pure @safe real std.conv.toImpl!(real, immutable(char)[]).toImpl(immutable(char)[]) [0x4ca1b9]
??:? pure @safe real std.conv.to!(real).to!(immutable(char)[]).to(immutable(char)[]) [0x4c8ea3]
??:? @safe real std.functional.__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ.compose!(immutable(char)[]).compose(immutable(char)[]) [0x4c8e6b]
??:? @safe immutable(char)[] std.functional.__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ.compose!(immutable(char)[]).compose(immutable(char)[]) [0x4c8e33]
??:? @property @safe immutable(char)[] std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult.front() [0x4cb006]
??:? ref @safe std.algorithm.iteration.joiner!(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]).joiner(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]).Result std.algorithm.iteration.joiner!(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]).joiner(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]).Result.__ctor(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]) [0x4cb477]
??:? @safe std.algorithm.iteration.joiner!(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]).joiner(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]).Result std.algorithm.iteration.joiner!(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]).joiner(std.algorithm.iteration.__T9MapResultS1633std10functional136__T7composeS253std4conv11__T2toTAyaZ2toS933std10functional67__T7composeS27_D3std4math5roundFNbNiNeeZeS223std4conv9__T2toTeZ2toZ7composeZ7composeTAAyaZ.MapResult, immutable(char)[]) [0x4cb2c9]
??:? _Dmain [0x4a7746]
??:? _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [0x4dbe82]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x4dbdd8]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0x4dbe3e]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x4dbdd8]
??:? _d_run_main [0x4dbd35]
??:? main [0x4d7669]
??:? __libc_start_main [0x40b6ba14]
```