### PR TITLE
MREF macro for linking to modules

### DIFF
--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -3,9 +3,7 @@ XREF = std.$1.$2
 XREF_PACK = std.$1.$2.$3
 CXREF = core.$1.$2
 ECXREF = etc.$1.$2
-MREF_HELPER=/$1$(MREF_HELPER $+)
-MREF_HELPER2=.$1$(MREF_HELPER2 $+)
-MREF=<a href="/library/$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
+MREF=<a href="/library/$1$(SLASH_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 LREF = $1
 ROOT_DIR=/
 _=

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -3,6 +3,9 @@ XREF = std.$1.$2
 XREF_PACK = std.$1.$2.$3
 CXREF = core.$1.$2
 ECXREF = etc.$1.$2
+MREF_HELPER=/$1$(MREF_HELPER $+)
+MREF_HELPER2=.$1$(MREF_HELPER2 $+)
+MREF=<a href="/library/$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
 LREF = $1
 ROOT_DIR=/
 _=

--- a/std.ddoc
+++ b/std.ddoc
@@ -13,6 +13,9 @@ _=
 CXREF = <a href="core_$1.html#$2">$(D core.$1.$2)</a>
 ECXREF = <a href="etc_c_$1.html#$2">$(D etc.c.$1.$2)</a>
 LREF = <a href="#$1">$(D $1)</a>
+MREF_HELPER=_$1$(MREF_HELPER $+)
+MREF_HELPER2=.$1$(MREF_HELPER2 $+)
+MREF=<a href="$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
 _=
 
 LEADINGROW = <tr class="leadingrow"><td colspan="2"><b><em>$(NBSP)$(NBSP)$(NBSP)$(NBSP)$0</em></b></td></tr>

--- a/std.ddoc
+++ b/std.ddoc
@@ -13,9 +13,10 @@ _=
 CXREF = <a href="core_$1.html#$2">$(D core.$1.$2)</a>
 ECXREF = <a href="etc_c_$1.html#$2">$(D etc.c.$1.$2)</a>
 LREF = <a href="#$1">$(D $1)</a>
-MREF_HELPER=_$1$(MREF_HELPER $+)
-MREF_HELPER2=.$1$(MREF_HELPER2 $+)
-MREF=<a href="$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
+SLASH_PREFIXED=/$1$(SLASH_PREFIXED $+)
+UNDERSCORE_PREFIXED=_$1$(UNDERSCORE_PREFIXED $+)
+DOT_PREFIXED=.$1$(DOT_PREFIXED $+)
+MREF=<a href="$1$(UNDERSCORE_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 _=
 
 LEADINGROW = <tr class="leadingrow"><td colspan="2"><b><em>$(NBSP)$(NBSP)$(NBSP)$(NBSP)$0</em></b></td></tr>


### PR DESCRIPTION
Usage: `$(MREF std,algorithm,searching)` or `$(MREF std,file)`. Returns a link to the given module. Unlike the existing cases of `$(LINK2)`, this also works in ddox as well as ddoc.