### PR TITLE
New macros

### DIFF
--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -8,4 +8,9 @@ MREF_HELPER2=.$1$(MREF_HELPER2 $+)
 MREF=<a href="/library/$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
 LREF = $1
 ROOT_DIR=/
+NOTE = <div class="note">$0</div>
+WARNING = <div class="warning">$0</div>
+PITFALL = <div class="pitfall">$0</div>
+TIP = <div class="tip">$0</div>
+SIDEBAR = <div class="sidebar">$0</div>
 _=

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -3,8 +3,6 @@ XREF = std.$1.$2
 XREF_PACK = std.$1.$2.$3
 CXREF = core.$1.$2
 ECXREF = etc.$1.$2
-MREF_HELPER=/$1$(MREF_HELPER $+)
-MREF_HELPER2=.$1$(MREF_HELPER2 $+)
-MREF=<a href="/library/$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
+MREF=<a href="/library/$1$(SLASH_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 LREF = $1
 ROOT_DIR=/

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -8,9 +8,3 @@ MREF_HELPER2=.$1$(MREF_HELPER2 $+)
 MREF=<a href="/library/$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
 LREF = $1
 ROOT_DIR=/
-NOTE = <div class="note">$0</div>
-WARNING = <div class="warning">$0</div>
-PITFALL = <div class="pitfall">$0</div>
-TIP = <div class="tip">$0</div>
-SIDEBAR = <div class="sidebar">$0</div>
-_=

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -3,6 +3,9 @@ XREF = std.$1.$2
 XREF_PACK = std.$1.$2.$3
 CXREF = core.$1.$2
 ECXREF = etc.$1.$2
+MREF_HELPER=/$1$(MREF_HELPER $+)
+MREF_HELPER2=.$1$(MREF_HELPER2 $+)
+MREF=<a href="/library/$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
 LREF = $1
 ROOT_DIR=/
 _=

--- a/std.ddoc
+++ b/std.ddoc
@@ -13,6 +13,9 @@ _=
 CXREF = <a href="core_$1.html#$2">$(D core.$1.$2)</a>
 ECXREF = <a href="etc_c_$1.html#$2">$(D etc.c.$1.$2)</a>
 LREF = <a href="#$1">$(D $1)</a>
+MREF_HELPER=_$1$(MREF_HELPER $+)
+MREF_HELPER2=.$1$(MREF_HELPER2 $+)
+MREF=<a href="$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
 _=
 
 LEADINGROW = <tr class="leadingrow"><td colspan="2"><b><em>$(NBSP)$(NBSP)$(NBSP)$(NBSP)$0</em></b></td></tr>

--- a/std.ddoc
+++ b/std.ddoc
@@ -26,9 +26,10 @@ _=
 CXREF = <a href="core_$1.html#$2">$(D core.$1.$2)</a>
 ECXREF = <a href="etc_c_$1.html#$2">$(D etc.c.$1.$2)</a>
 LREF = <a href="#$1">$(D $1)</a>
-MREF_HELPER=_$1$(MREF_HELPER $+)
-MREF_HELPER2=.$1$(MREF_HELPER2 $+)
-MREF=<a href="$1$(MREF_HELPER $+).html">$1$(MREF_HELPER2 $+)</a>
+SLASH_PREFIXED=/$1$(SLASH_PREFIXED $+)
+UNDERSCORE_PREFIXED=_$1$(UNDERSCORE_PREFIXED $+)
+DOT_PREFIXED=.$1$(DOT_PREFIXED $+)
+MREF=<a href="$1$(UNDERSCORE_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 _=
 
 LEADINGROW = <tr class="leadingrow"><td colspan="2"><b><em>$(NBSP)$(NBSP)$(NBSP)$(NBSP)$0</em></b></td></tr>

--- a/std.ddoc
+++ b/std.ddoc
@@ -10,6 +10,19 @@ $(SCRIPT jQuery(document).ready(listanchors);)
 LAYOUT_TITLE=$(H1 $(D $(TITLE)))
 _=
 
+_= a NOTE is just something you want to draw attention to. e.g. "this function is Windows only"
+NOTE = <div class="note">$0</div>
+_= a WARNING is something that users often get wrong, but isn't necessarily fatal, like the difference between byLine and byLineCopy
+WARNING = <div class="warning">$0</div>
+_= PITFALL is something that if you get it wrong, your program will crash or other such serious consequences, like passing a GC reference to a C function to store
+PITFALL = <div class="pitfall">$0</div>
+_= a TIP is just a cool fact about using this item
+TIP = <div class="tip">$0</div>
+_= SIDEBAR is something for users who are interested into diving much deeper than they have to to understand the function. It should just contain a short sentence and probably a link to learn more.
+SIDEBAR = <div class="sidebar">$0</div>
+
+_=
+
 CXREF = <a href="core_$1.html#$2">$(D core.$1.$2)</a>
 ECXREF = <a href="etc_c_$1.html#$2">$(D etc.c.$1.$2)</a>
 LREF = <a href="#$1">$(D $1)</a>


### PR DESCRIPTION
This is a follow-up to https://github.com/D-Programming-Language/dlang.org/pull/1177 and assumes that one gets merged first.

I like to use these new macros when writing documentation to call out certain parts of the text (or in the case of SIDEBAR, to put it there with*out* drawing attention to it).

The look can be defined elsewhere.

I want to change cases like `$(RED Important note:) blah blah` in some Phobos functions to `$(DANGER blah blah)` and `$(BLUE This function is Windows only)` to `$(NOTE this function is Windows only)` to we can restyle them more easily.


I also intend to use these in writing my doc additions, which hopefully we can get into Phobos itself too with minimal disruption to the dlang.org site