### PR TITLE
Issue 15471: Associative Arrays: add example of static initialization

### DIFF
--- a/spec/hash-map.dd
+++ b/spec/hash-map.dd
@@ -22,7 +22,7 @@ $(SPEC_S Associative Arrays,
         $(P $(BLUE $(B Note:)) The built-in associative arrays do not preserve the order
         of the keys inserted into the array. In particular, in a $(D foreach) loop the
         order in which the elements are iterated is unspecified.)
-        
+
 $(H3 Removing Keys)
 
         $(P Particular keys in an associative array can be removed with the
@@ -46,7 +46,7 @@ $(H3 Testing Membership)
 
         ---------
         int* p;
-        
+
         p = ("hello" $(CODE_HIGHLIGHT in) aa);
         if (p !is null)
         {
@@ -235,6 +235,23 @@ $(H3 Construction or Assignment on Setting AA Entries)
         aa["a"] = 20;   // call aa["a"].opAssign(20)
         ---------
     )
+
+$(H3 Static Initialization of AAs)
+
+        ---------
+        immutable long[string] aa = [
+          "foo": 5,
+          "bar": 10,
+          "baz": 2000
+        ];
+
+        unittest
+        {
+            assert(aa["foo"] == 5);
+            assert(aa["bar"] == 10);
+            assert(aa["baz"] == 2000);
+        }
+        ---------
 
 $(H3 Runtime Initialization of Immutable AAs)
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15471

![screen shot 2016-01-03 at 7 24 07 pm](https://cloud.githubusercontent.com/assets/2280568/12082973/9760b7e4-b24f-11e5-9f7c-6107d00a5ff8.png)

FWIW: The extra whitespace was auto-removed by my setup, I checked and it does not change the rendered html page.