### PR TITLE
Wrong variable naming in the example

### DIFF
--- a/migrate-to-shared.dd
+++ b/migrate-to-shared.dd
@@ -119,8 +119,8 @@ shared int flag;
 	)
 
 ---
-int* p = &flags;           // error, flags is shared
-shared(int)* q = &flags;   // ok
+int* p = &flag;           // error, flag is shared
+shared(int)* q = &flag;   // ok
 ---
 
 	$(P The $(CODE shared) type attribute is transitive (like


### PR DESCRIPTION
On top the variable is defined as "flag" but on the bottom, it is used as "flags" while both of them should have been same.