### PR TITLE
Add new macro REF, a variadic and more general XREF

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -133,6 +133,8 @@ DDOCKEYVAL2=$(DIVC keyval $1, $(SPANC key key$1, $2:) $(DIVC val val$1, $(TAIL $
 DDSUBLINK=$(LINK2 $(ROOT_DIR)$1.html#$2, $3)
 _=
 
+DOT_PREFIXED=.$1$(DOT_PREFIXED $+)
+DOT_PREFIXED_SKIP=$(DOT_PREFIXED $+)
 DRUNTIMESRC=$(HTTPS github.com/D-Programming-Language/druntime/blob/master/src/$0, $0)
 DPLLINK=$(LINK2 $1,$+)
 _=
@@ -198,6 +200,7 @@ MULTICOL_CELL=<td colspan="$1">$+</td>
 MULTICOL_HEADER=<th colspan="$1">$+</th>
 MULTICOLS=$+
 MULTIROW_HEADER=<th rowspan="$1">$+</th>
+MREF=<a href="$(ROOT_DIR)phobos/$1$(UNDERSCORE_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 _=
 
 NEWS=http://digitalmars.com/webnews/newsgroups.php?search_txt=$(AMP)group=$1$(AMP)article_id=$+
@@ -241,6 +244,8 @@ PHOBOSSRC=$(SPANC phobos_src, $(AHTTPS github.com/D-Programming-Language/phobos/
 _=
 
 RED=$(SPANC red, $0)
+REF=<a href="$(ROOT_DIR)phobos/$2$(UNDERSCORE_PREFIXED_SKIP $+).html#$1">$(D $2$(DOT_PREFIXED_SKIP $+, $1))</a>
+REF_ALTTEXT=<a href="$(ROOT_DIR)phobos/$3$(UNDERSCORE_PREFIXED_SKIP2 $+).html#$2">$1</a>
 RELATIVE_LINK2=$(ALOCAL $1, $+)
 _=
 
@@ -274,6 +279,7 @@ SECTION2=$(H2 $1)$+
 SECTION3=$(H3 $1)$+
 SECTION4=$(H4 $1)$+
 SECTION5=$(H5 $1)$+
+SLASH_PREFIXED=/$1$(SLASH_PREFIXED $+)
 STATIC=$(ROOT_DIR)$1
 SUBMENU=<ul>$(SUBMENU2 $1,$+)</ul></li>
 SUBMENU2=<li><a href='$1'>$2</a></li>$(SUBMENU3 $+)
@@ -298,6 +304,9 @@ TROW_EXPLANATORY=<td colspan="10">$0</td>
 _=
 
 UNDERSCORE=_
+UNDERSCORE_PREFIXED=_$1$(UNDERSCORE_PREFIXED $+)
+UNDERSCORE_PREFIXED_SKIP=$(UNDERSCORE_PREFIXED $+)
+UNDERSCORE_PREFIXED_SKIP2=$(UNDERSCORE_PREFIXED_SKIP $+)
 _=
 
 VERTROW=$(TR $(TDX $1, $+))

--- a/macros.ddoc
+++ b/macros.ddoc
@@ -2,7 +2,7 @@ _=Fundamental macros that apply to all generated formats
 
 ARGS = $0
 COMMA = ,
-COMMENT = 
+COMMENT =
 DOLLAR = $
 LPAREN = (
 RPAREN = )

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -3,7 +3,10 @@ XREF = std.$1.$2
 XREF_PACK = std.$1.$2.$3
 CXREF = core.$1.$2
 ECXREF = etc.$1.$2
-MREF=<a href="/library/$1$(SLASH_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
+MREF=<a href="$(ROOT_DIR)library/$1$(SLASH_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 LREF = $1
 ROOT_DIR=/
+_=
+
+REF=$2$(DOT_PREFIXED_SKIP $+).$1
 _=

--- a/std.ddoc
+++ b/std.ddoc
@@ -13,10 +13,6 @@ _=
 CXREF = <a href="core_$1.html#$2">$(D core.$1.$2)</a>
 ECXREF = <a href="etc_c_$1.html#$2">$(D etc.c.$1.$2)</a>
 LREF = <a href="#$1">$(D $1)</a>
-SLASH_PREFIXED=/$1$(SLASH_PREFIXED $+)
-UNDERSCORE_PREFIXED=_$1$(UNDERSCORE_PREFIXED $+)
-DOT_PREFIXED=.$1$(DOT_PREFIXED $+)
-MREF=<a href="$1$(UNDERSCORE_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 _=
 
 LEADINGROW = <tr class="leadingrow"><td colspan="2"><b><em>$(NBSP)$(NBSP)$(NBSP)$(NBSP)$0</em></b></td></tr>


### PR DESCRIPTION
Usage is like:
```
$(REF File.writeln, std, stdio)
$(REF splitter, std, algorithm, iteration)
$(REF_ALTTEXT forward range, isForwardRange, std, range, primitives)
```
Added to dlang.org.ddoc because that's where XREF is defined. Can be used to link to symbols rooted in `std`, `core`, `etc` or any other root package.

Implementation is a bit messy. I don't know quite why, but using TAIL instead of those helper macros didn't work. Commas showed up in the output.

Will implement for DDox output ASAP.