### PR TITLE
Let DDox handle module references

### DIFF
--- a/latex.ddoc
+++ b/latex.ddoc
@@ -213,6 +213,7 @@ MULTICOL_CELL=\multicolumn{$1}{l}{$+}
 MULTICOL_HEADER=\multicolumn{$1}{l}{$+}
 MULTICOLS=\begin{multicols}{$1}$+ \end{multicols}
 MULTIROW_HEADER=\multirow{$1}{*}{$+}
+MREF=$(D $1$(DOT_PREFIXED $+))
 _=
 
 NBSP=~
@@ -240,6 +241,7 @@ _=
 
 RCURL=$\}$
 RED={\color{red}$0}
+REF=$(D $2$(DOT_PREFIXED_SKIP $+).$1)
 REG=$(COPY)
 RELATIVE_LINK2=$(LINK2 $1,$+)
 _=

--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -3,10 +3,10 @@ XREF = std.$1.$2
 XREF_PACK = std.$1.$2.$3
 CXREF = core.$1.$2
 ECXREF = etc.$1.$2
-MREF=<a href="$(ROOT_DIR)library/$1$(SLASH_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 LREF = $1
 ROOT_DIR=/
 _=
 
-REF=$2$(DOT_PREFIXED_SKIP $+).$1
+REF=$(D $2$(DOT_PREFIXED_SKIP $+).$1)
+MREF=$(D $1$(DOT_PREFIXED $+))
 _=


### PR DESCRIPTION
It looks like DDox detects and handles module references in the same way it detects symbol references. This fixes module references in `/library-prerelease/` and removes `<a>`-inside-`<a>` shenanigans.

DDox doesn't appear to detect module references if they appear the end of a punctuated sentence, like `see std.algorithm.`; I'll file that over at the DDox repository.