### PR TITLE
update dmd and dub used for dpl-docs

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -25,8 +25,8 @@ REMOTE_DIR=d-programming@digitalmars.com:data
 GENERATED=.generated
 
 # stable dub and dmd versions used to build dpl-docs
-DUB_VER=0.9.23
-STABLE_DMD_VER=2.067.1
+DUB_VER=0.9.24
+STABLE_DMD_VER=2.069.2
 STABLE_DMD_ROOT=/tmp/.stable_dmd-$(STABLE_DMD_VER)
 STABLE_DMD_URL=http://downloads.dlang.org/releases/2.x/$(STABLE_DMD_VER)/dmd.$(STABLE_DMD_VER).$(OS).zip
 STABLE_DMD=$(STABLE_DMD_ROOT)/dmd2/$(OS)/$(if $(filter $(OS),osx),bin,bin$(MODEL))/dmd


### PR DESCRIPTION
- avoids issues w/ libcurl
- quite some new deprecation warnings due to libdparse