### PR TITLE
use no-as-needed to workaround dmd's link order issues

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -471,12 +471,19 @@ docs-prerelease.json : ${DMD} ${DRUNTIME_DIR} \
 # binary targets for DDOX
 ################################################################################
 
+# workardound Issue 15574
+ifneq (osx,$(OS))
+    DPL_DOCS_DFLAGS=-conf=$(abspath ${STABLE_DMD_CONF}) -L--no-as-needed
+else
+    DPL_DOCS_DFLAGS=-conf=$(abspath ${STABLE_DMD_CONF})
+endif
+
 .PHONY: dpl-docs
 dpl-docs: ${DUB} ${STABLE_DMD}
 	# the "dub upgrade" and "--missing-only" parts are required only as a
 	# workaround for DUB issue #564 (0.9.23)
 	${DUB} upgrade --missing-only --root=${DPL_DOCS_PATH}
-	DFLAGS="-conf=$(abspath ${STABLE_DMD_CONF})" ${DUB} build --nodeps --root=${DPL_DOCS_PATH} \
+	DFLAGS="$(DPL_DOCS_DFLAGS)" ${DUB} build --nodeps --root=${DPL_DOCS_PATH} \
 		--compiler=${STABLE_DMD}
 
 ${STABLE_DMD}:


### PR DESCRIPTION
- mainly affects Ubuntu which uses as-needed by default