### PR TITLE
don't overwrite install.sh/install.sh.sig when rsyncing

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -279,7 +279,7 @@ clean:
 	rm -f docs.json docs-prerelease.json dpl-docs/dpl-docs
 	@echo You should issue manually: rm -rf ${DMD_DIR}-${LATEST} ${DRUNTIME_DIR}-${LATEST} ${PHOBOS_DIR}-${LATEST} ${STABLE_DMD_ROOT} ${DUB_DIR}
 
-RSYNC_FILTER=-f 'P /Usage' -f 'P /.dpl_rewrite*'
+RSYNC_FILTER=-f 'P /Usage' -f 'P /.dpl_rewrite*' -f 'P /install.sh*'
 
 rsync : all kindle pdf
 	rsync -avzO --chmod=u=rwX,g=rwX,o=rX --delete $(RSYNC_FILTER) $(DOC_OUTPUT_DIR)/ $(REMOTE_DIR)/


### PR DESCRIPTION
- meant for the https://dlang.org/install.sh script