### PR TITLE
remove .subnav's border-left in narrow layouts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1685,6 +1685,7 @@ input.resetButton{display: none}
     {
         float: none;
         border-bottom-width: 1px;
+        border-left-width: 0;
         border-right-width: 0;
         margin: 0 -1em;
         padding: 0.6em 1em;


### PR DESCRIPTION
Forgot this when I added the border-left.

Before/after: 
![snapshot1](https://cloud.githubusercontent.com/assets/9287500/12397964/f3522188-be10-11e5-92de-636a50f90fd3.png)

