### PR TITLE
new logo variant: no borders, less effects, wide planet arc

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -110,13 +110,14 @@ body > .container
 {
     display: block;
     float: left;
-    margin-right: 1em;
+    margin-left: -5.4em;
+    margin-right: -4em;
     padding-top: 1px;
 }
 
 #top img#logo
 {
-    height: 2.5em;
+    height: 2.533em;
     vertical-align: middle;
     width: auto;
 }

--- a/images/dlogo.svg
+++ b/images/dlogo.svg
@@ -1,216 +1,84 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!-- This version is meant to be centered and cropped left/right as needed. -->
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
-   width="49.544645"
-   height="37.5"
-   viewBox="0 0 123.86523 93.752739"
-   id="svg2">
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient3482">
-      <stop
-         id="stop3484"
-         style="stop-color:#000000;stop-opacity:0.19791667"
-         offset="0" />
-      <stop
-         id="stop3486"
-         style="stop-color:#000000;stop-opacity:0.82291669"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3456">
-      <stop
-         id="stop3458"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3460"
-         style="stop-color:#ffffff;stop-opacity:0.33333334"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3420">
-      <stop
-         id="stop3430"
-         style="stop-color:#f2f2f0;stop-opacity:0.13541667"
-         offset="0" />
-      <stop
-         id="stop3424"
-         style="stop-color:#eeeeec;stop-opacity:0.39583334"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3360">
-      <stop
-         id="stop3362"
-         style="stop-color:#eeeeec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3364"
-         style="stop-color:#eeeeec;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3307">
-      <stop
-         id="stop3309"
-         style="stop-color:#a5d8ff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3311"
-         style="stop-color:#003845;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3299">
-      <stop
-         id="stop3301"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3303"
-         style="stop-color:#979797;stop-opacity:0.57291669"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="27.247862"
-       y1="33.562527"
-       x2="44.49588"
-       y2="47.030663"
-       id="linearGradient3426"
-       xlink:href="#linearGradient3420"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.991763,-0.677924,0.501242)"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="24.48222"
-       y1="30.993589"
-       x2="104.02448"
-       y2="90.718597"
-       id="linearGradient3462"
-       xlink:href="#linearGradient3456"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99719,0,0,0.988716,-0.49737,0.686728)" />
-    <linearGradient
-       x1="49.344894"
-       y1="57.756798"
-       x2="79.688202"
-       y2="83.106018"
-       id="linearGradient3488"
-       xlink:href="#linearGradient3482"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       x1="27.247862"
-       y1="33.562527"
-       x2="44.49588"
-       y2="47.030663"
-       id="linearGradient2213"
-       xlink:href="#linearGradient3420"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,-0.991763,-0.677924,121.0142)"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="27.247862"
-       y1="33.562527"
-       x2="44.49588"
-       y2="47.030663"
-       id="linearGradient2232"
-       xlink:href="#linearGradient3420"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,-0.991763,-0.677924,121.0142)"
-       spreadMethod="reflect" />
-  </defs>
-  <metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     transform="translate(-2.9819053,-15.753182)"
-     id="layer1">
-    <g
-       transform="matrix(1.475092,0,0,1.475092,-30.36508,-28.63879)"
-       id="g2225"
-       style="display:inline">
-      <rect
-         width="80.581573"
-         height="60.167591"
-         rx="7.6942425"
-         ry="8.5425425"
-         x="25.996332"
-         y="33.483997"
-         id="rect3466"
-         style="fill:#2e3436;fill-opacity:0.2745098;fill-rule:nonzero;stroke:none" />
-      <rect
-         width="80.581573"
-         height="60.167591"
-         rx="7.6942425"
-         ry="8.5425425"
-         x="23.284639"
-         y="30.772299"
-         id="rect3297"
-         style="fill:#a40000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <rect
-         width="74.010971"
-         height="54.137524"
-         rx="5.2214007"
-         ry="5.6200938"
-         x="26.569939"
-         y="33.787331"
-         id="rect3408"
-         style="fill:url(#linearGradient3426);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="m 32.333318,39.18804 c -0.810423,0.100191 -1.445546,0.747081 -1.448237,1.530008 l 0.05115,39.976517 c -0.0033,0.05702 -0.0032,0.117055 2.23e-4,0.174065 -0.0093,0.0949 -0.0092,0.175886 3.47e-4,0.270764 -8.2e-5,0.0095 -5.8e-5,0.02917 4.9e-5,0.03868 0.0087,0.03837 0.0298,0.07834 0.04158,0.115983 -8.1e-5,0.0095 -8.1e-5,0.0098 2.5e-5,0.01934 0.0087,0.03838 0.0091,0.07837 0.02087,0.116011 -8.3e-5,0.0095 -5.7e-5,0.02917 4.9e-5,0.03868 0.01873,0.03878 0.04021,0.07874 0.0623,0.115951 -8e-5,0.0095 -8.1e-5,0.0098 2.5e-5,0.01934 0.02872,0.03929 0.07126,0.07924 0.103734,0.115892 -8.2e-5,0.0095 -8.2e-5,0.0098 2.4e-5,0.01934 0.01873,0.03878 0.04021,0.07875 0.0623,0.115952 -8.2e-5,0.0095 -5.7e-5,0.02917 4.9e-5,0.03868 0.03935,0.03021 0.08223,0.05048 0.124402,0.07718 -8.3e-5,0.0095 -5.7e-5,0.02917 4.9e-5,0.03868 0.02939,0.02959 0.05119,0.04989 0.08297,0.07724 0.01007,0.0096 0.03115,0.02925 0.04148,0.03862 0.02939,0.02959 0.05119,0.04989 0.08297,0.07724 0.01018,7.1e-5 0.01053,7.3e-5 0.02072,-3e-5 0.07575,0.06385 0.161798,0.123919 0.248826,0.173699 0.01019,7e-5 0.03125,4.4e-5 0.04143,-6e-5 0.03991,0.02052 0.08278,0.04046 0.124377,0.05784 0.01018,7e-5 0.01053,7.1e-5 0.02072,-2.9e-5 0.03992,0.02052 0.08279,0.04046 0.124376,0.05784 0.06051,0.01261 0.124828,0.01286 0.186479,0.01907 0.100723,0.01817 0.208212,0.03772 0.310804,0.03823 l 0.165737,-2.42e-4 15.309845,-0.06107 c 4.376235,-0.0078 7.307373,-0.08265 9.052976,-0.303342 0.01019,7.1e-5 0.03125,4.2e-5 0.04143,-6.2e-5 1.670518,-0.232037 3.440036,-0.65958 5.36408,-1.284309 3.344758,-1.045783 6.310742,-2.590914 8.860956,-4.65465 2.496912,-1.999262 4.431819,-4.366287 5.791789,-7.029031 1.359852,-2.662676 2.045357,-5.47805 2.040248,-8.396714 -0.0072,-4.062678 -1.236199,-7.866897 -3.702086,-11.289377 -2.466138,-3.422627 -5.83233,-6.043726 -9.974869,-7.779593 -4.211418,-1.785447 -9.702531,-2.598978 -16.514823,-2.586807 l -16.532201,0.02417 c -0.07107,3.95e-4 -0.138489,-0.0082 -0.207171,3.03e-4 z m 8.898154,8.225996 7.126664,-0.01042 c 3.330616,-0.0059 5.700107,0.09523 7.044164,0.279807 1.362489,0.187177 2.854705,0.582181 4.434981,1.192619 1.56625,0.596782 2.931614,1.327683 4.104845,2.237482 -8e-5,0.0095 -5.6e-5,0.02917 5e-5,0.03868 3.227673,2.470818 4.74922,5.440832 4.756204,9.373135 0.0071,4.02642 -1.463298,7.162711 -4.607379,9.792976 -0.967178,0.798314 -2.042682,1.475215 -3.22926,2.035463 -1.121501,0.522301 -2.58442,0.97246 -4.431715,1.360307 -1.742195,0.348503 -4.387131,0.54682 -7.83035,0.552979 l -7.333833,0.01072 -0.03437,-26.863756 z"
-         id="path2242"
-         style="font-size:64px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#eeeeec;fill-opacity:1;stroke:none;font-family:Gill Sans MT" />
-      <path
-         d="m 89.367876,35.647667 a 5.9689121,5.4715028 0 1 1 -11.937824,0 5.9689121,5.4715028 0 1 1 11.937824,0 z"
-         transform="matrix(1.950025,0,0,1.950025,-82.91788,-16.34322)"
-         id="path2211"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <rect
-         width="78.006226"
-         height="57.749683"
-         rx="6.5702238"
-         ry="7.3061213"
-         x="24.572311"
-         y="31.981253"
-         id="rect3372"
-         style="fill:none;stroke:url(#linearGradient3462);stroke-width:1.34628034;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <rect
-         width="80.581573"
-         height="60.167591"
-         rx="7.6942425"
-         ry="8.5425425"
-         x="23.284639"
-         y="30.772299"
-         id="rect3464"
-         style="fill:none;stroke:#323232;stroke-width:1.3558476;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 31.791339,87.728149 63.56817,0 c 2.892656,0 5.221401,-2.506561 5.221401,-5.620093 l 0,-9.001145 C 77.875731,64.373285 45.003847,59.694557 26.569939,59.548435 l 0,22.559621 c 0,3.113532 2.328744,5.620093 5.2214,5.620093 z"
-         id="rect3477"
-         style="fill:url(#linearGradient2232);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="m 89.367876,35.647667 a 5.9689121,5.4715028 0 1 1 -11.937824,0 5.9689121,5.4715028 0 1 1 11.937824,0 z"
-         transform="matrix(0.626567,0,0,0.626567,40.72046,19.11002)"
-         id="path2222"
-         style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+    version="1.0"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    height="38"
+    viewBox="0 0 481 89"
+>
+    <defs>
+        <linearGradient
+            x1="66"
+            y1="50"
+            x2="60"
+            y2="99"
+            id="gradient"
+            gradientUnits="userSpaceOnUse">
+            <stop style="stop-color: white; stop-opacity: 1" offset="0" />
+            <stop style="stop-color: white; stop-opacity: 0" offset="1" />
+        </linearGradient>
+    </defs>
+
+    <!-- background -->
+    <rect width="100%" height="100%" style="fill: #C25454; fill: #B03931" />
+
+    <g transform="translate(181,0)">
+        <!-- planet (originally a shiny effect, I guess) -->
+        <ellipse cx="-4.5" cy="308" rx="310" ry="266"
+            style="fill: url(#gradient); opacity: 0.3;"/>
+
+        <!-- bigger moon -->
+        <ellipse style="fill: #fff" rx="12" ry="11"
+            transform="translate(83.2177260627967172,32.7927689136800591)
+                scale(1.43078119731816044417)" />
+
+        <!-- smaller moon -->
+        <ellipse style="fill: #fff" rx="12" ry="11"
+            transform="translate(102.782334293845546096,15.497388861356540388)
+                scale(0.45972758424125220703)" />
+
+        <!-- D -->
+        <path
+            style="fill: #fff"
+            transform="translate(-34.36508,-45.63879) scale(1.475092)"
+            d="M 32.333318,39.18804
+
+            C 31.522895,39.288231 30.887772,39.935121 30.885081,40.718048
+
+            L 30.93623,80.694565
+
+            C 30.93623,81.3 31.1,82.548514 32.80314,82.548514
+
+            L 48.112985,82.487448
+
+            C 52.48922,82.479605 55.420358,82.404795 57.165961,82.184106
+            C 57.176148,82.184177 57.197209,82.184148 57.207395,82.184044
+            C 58.877913,81.952007 60.647431,81.524464 62.571475,80.899735
+            C 65.916233,79.853952 68.882217,78.308821 71.432431,76.245085
+            C 73.929343,74.245823 75.86425,71.878798 77.22422,69.216054
+            C 78.584072,66.553378 79.269577,63.738004 79.264468,60.81934
+            C 79.25724,56.756662 78.028269,52.952443 75.562382,49.529963
+            C 73.096244,46.107336 69.730052,43.486237 65.587513,41.75037
+            C 61.376095,39.964923 55.884982,39.151392 49.07269,39.163563
+            L 32.540489,39.187737
+            C 32.469417,39.188132 32.402,39.179549 32.333318,39.18804
+            z
+
+            M 41.231472,47.414036
+            L 48.358136,47.403617
+
+            C 51.688752,47.397684 54.058243,47.498843 55.4023,47.683424
+            C 56.764789,47.870601 58.257005,48.265605 59.837281,48.876043
+            C 61.403531,49.472825 62.768895,50.203726 63.942126,51.113525
+            C 67.169849,53.623026 68.691396,56.59304 68.69838,60.525343
+            C 68.705455,64.551763 67.235082,67.688054 64.091001,70.318319
+            C 63.123823,71.116633 62.048319,71.793534 60.861741,72.353782
+            C 59.74024,72.876083 58.277321,73.326242 56.430026,73.714089
+            C 54.687831,74.062592 52.042895,74.260909 48.599676,74.267068
+
+            L 41.265843,74.277792
+            L 41.231472,47.414036
+            z" />
     </g>
-  </g>
 </svg>


### PR DESCRIPTION
Also made the logo white (#fff); it was almost white before (#eeeeec).
And smoothed out two rough edges in the D shape. Shoutout to WebFreak001
for spotting that.

Forum thread: http://forum.dlang.org/post/n7rqki$pqo$1@digitalmars.com

Screenshot:
![screen shot 2016-01-24 at 16 05 49](https://cloud.githubusercontent.com/assets/9287500/12536982/829f1876-c2b4-11e5-9806-05f482a648c8.png)

And in a narrower window, when the logo is pushed to the window border:
![screen shot 2016-01-24 at 16 07 35](https://cloud.githubusercontent.com/assets/9287500/12536988/a7995920-c2b4-11e5-9a40-0b99d470a117.png)

Before/after shots of the D shape fixes (magnified a lot):

Outside, bottom left: ![diff-a-before](https://cloud.githubusercontent.com/assets/9287500/12536992/c97d9740-c2b4-11e5-9477-158d387092fa.png) ![diff-a-after](https://cloud.githubusercontent.com/assets/9287500/12536993/c97d9bf0-c2b4-11e5-9a27-e667a7a36663.png)
Inside, top right: ![diff-b-before](https://cloud.githubusercontent.com/assets/9287500/12536995/c97f66d8-c2b4-11e5-9b7e-7fb74e978b1e.png) ![diff-b-after](https://cloud.githubusercontent.com/assets/9287500/12536994/c97ebd00-c2b4-11e5-9f83-dcd4e37e8fd8.png)
