### PR TITLE
Link to alpha mobile compiler releases

### DIFF
--- a/download.dd
+++ b/download.dd
@@ -37,7 +37,11 @@ $(TABLEC download-compilers,
       $(UL
         $(LI $(LINK2 http://llvm.org/, LLVM)-based D compiler)
         $(LI Strong optimization)
-        $(LI Architectures: i386, amd64, $(LINK2 https://wiki.dlang.org/Compilers#Comparison,others))
+        $(LI Alpha support for mobile:
+          $(LINK2 https://github.com/smolt/ldc-iphone-dev/releases, iOS),
+          $(LINK2 https://github.com/joakim-noah/android/releases, Android)
+        )
+        $(LI Architectures: i386, amd64, armel, $(LINK2 https://wiki.dlang.org/Compilers#Comparison,others))
       )
     )
   )


### PR DESCRIPTION
~~Only missing [the Android logo](https://commons.m.wikimedia.org/wiki/File:Android_robot.png), would appreciate if someone would process that image as needed and submit a PR with the Android logo.  I've used the openSUSE logo as a placeholder for now.~~ No logos needed anymore, much simpler.