### PR TITLE
add leading dot to anchors generated by REF/REF_ALTTEXT

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -295,8 +295,8 @@ PHOBOSSRC=$(SPANC phobos_src, $(AHTTPS github.com/D-Programming-Language/phobos/
 _=
 
 RED=$(SPANC red, $0)
-REF=<a href="$(PHOBOS_PATH)$2$(UNDERSCORE_PREFIXED_SKIP $+).html#$1">$(D $2$(DOT_PREFIXED_SKIP $+, $1))</a>
-REF_ALTTEXT=<a href="$(PHOBOS_PATH)$3$(UNDERSCORE_PREFIXED_SKIP2 $+).html#$2">$1</a>
+REF=<a href="$(PHOBOS_PATH)$2$(UNDERSCORE_PREFIXED_SKIP $+).html#.$1">$(D $2$(DOT_PREFIXED_SKIP $+, $1))</a>
+REF_ALTTEXT=<a href="$(PHOBOS_PATH)$3$(UNDERSCORE_PREFIXED_SKIP2 $+).html#.$2">$1</a>
 RELATIVE_LINK2=$(ALOCAL $1, $+)
 _=
 


### PR DESCRIPTION
Stumbled over REF missing the leading dot when using it in the phobos changelog: https://github.com/D-Programming-Language/phobos/pull/3964