### PR TITLE
Fix issue 15697 - The TWID script is always served over HTTP

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -90,7 +90,7 @@ $(DIVC boxes,
                 before it's sold out!
             )
             $(P Stay updated with
-                $(LINK2 http://arsdnet.net/this-week-in-d,
+                $(LINK2 //arsdnet.net/this-week-in-d,
                     <cite>This Week in D</cite>),
                 Adam D. Ruppe's weekly newsletter. $(SPANC twid)
             )


### PR DESCRIPTION
This changes the script to use // for the protocol to fix issues like the script being ignored by Chrome and warnings being displayed in Edge / IE.

Would like to get approval from @adamdruppe that it's okay to serve the script from his website over HTTPs, in case the extra load is an issue.