### PR TITLE
Fix issue 15697 - The TWID script is always served over HTTP

### DIFF
--- a/index.dd
+++ b/index.dd
@@ -382,7 +382,7 @@ Macros:
     LAYOUT_PREFIX=
     LAYOUT_SUFFIX=
     $(SCRIPTLOAD $(ROOT_DIR)js/run-main-website.js)
-    $(SCRIPTLOAD http://arsdnet.net/this-week-in-d/twid-latest.js)
+    $(SCRIPTLOAD //arsdnet.net/this-week-in-d/twid-latest.js)
     LAYOUT_TITLE=
     TOUR=$(DIVC item, $(SECTION4 $(LINK2 $1, $(TC i, fa fa-$2 big-icon)$3), $4))
     TOUR=$(DIVC item, $(SECTION4 $(TC i, fa fa-$1 big-icon)$2, $3))


### PR DESCRIPTION
This changes the script to use // for the protocol to fix issues like the script being ignored by Chrome and warnings being displayed in Edge / IE.

Recreated pull after changing wrong link originally. I didn't test locally, so will need to wait for the documentation bot to generate it, I'll update the pull when checked.