### PR TITLE
make logo width explicit

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -119,7 +119,7 @@ body > .container
 {
     height: 2.533em;
     vertical-align: middle;
-    width: auto;
+    width: 13.69em;
 }
 
 #top #d-language


### PR DESCRIPTION
Fixes issue 15696 - The website logo overlaps the Learn tab when using
Microsoft Edge