### PR TITLE
use https for google search

### DIFF
--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -115,7 +115,7 @@ html(lang='en-US')
             a.expand-toggle(href="#{root_dir}search.html", title="Search")
               span Search
             #search-box
-              form(method='get', action='http://google.com/search')
+              form(method='get', action='https://google.com/search')
                 input#domains(type='hidden', name='domains', value='dlang.org')
                 |             
                 input#sourceid(type='hidden', name='sourceid', value='google-search')


### PR DESCRIPTION
If I currently visit https://dlang.org, I get the following error:

```
Mixed Content: The page at 'https://dlang.org/' was loaded over a secure connection, but contains a form which targets an insecure endpoint 'http://google.com/search'. This endpoint should be made available over a secure connection.
```

Btw since 2014 Google is [preferring HTTPS sites](https://googlewebmastercentral.blogspot.fi/2014/08/https-as-ranking-signal.html), so why not make SSL the default?