### PR TITLE
add missing anchors from "functions" to "Embedded Documentation"

### DIFF
--- a/spec/contracts.dd
+++ b/spec/contracts.dd
@@ -29,7 +29,7 @@ $(COMMENT <img src="../images/d4.gif" alt="Contracts make D bug resistant" borde
 	out of date, wrong, or non-existent. Moving the contracts into the code makes them
 	verifiable against the program.)
 
-$(H2 Assert Contract)
+$(H2 $(LNAME2 assert_contracts, Assert Contract))
 
 	$(P The most basic contract is the
 	$(GLINK2 expression, AssertExpression).
@@ -53,7 +53,7 @@ assert(expression);
 	$(P The compiler is free to assume the assert expression is true and
 	optimize subsequent code accordingly.)
 
-$(H2 Pre and Post Contracts)
+$(H2 $(LNAME2 pre_post_contracts, Pre and Post Contracts))
 
 	The pre contracts specify the preconditions before a statement is executed. The most
 	typical use of this would be in validating the parameters to a function. The post
@@ -125,7 +125,7 @@ body
 	In an out statement, $(I result) is initialized and set to the
 	return value of the function.
 
-$(H2 In, Out and Inheritance)
+$(H2 $(LNAME2 in_out_inheritance, In, Out and Inheritance))
 
 	$(P If a function in a derived class overrides a function in its
 	super class, then only one of
@@ -249,7 +249,7 @@ assert(&s);               // check that struct S invariant holds
 	The compiler is free to assume the invariant holds true, regardless of whether code is generated for it or not, and
 	may optimize code accordingly.)
 
-$(H2 References)
+$(H2 $(LNAME2 references, References))
 
 	$(LIST
 	$(LINK2 http://people.cs.uchicago.edu/~robby/contract-reading-list/, Contracts Reading List),

--- a/spec/errors.dd
+++ b/spec/errors.dd
@@ -19,7 +19,7 @@ $(UL
 	$(LI Requesting a system service that is not supported.)
 )
 
-$(H2 The Error Handling Problem)
+$(H2 $(LNAME2 the_error_handling_problem, The Error Handling Problem))
 
 The traditional C way of detecting and reporting errors is not traditional,
 it is ad-hoc and varies from function to function, including:
@@ -70,7 +70,7 @@ $(UL
 	$(LI It is easy to make the error handling source code look good.)
 )
 
-$(H2 The D Error Handling Solution)
+$(H2 $(LNAME2 the_d_error_handling_solution, The D Error Handling Solution))
 
 Let's first make some observations and assumptions about errors:
 

--- a/spec/float.dd
+++ b/spec/float.dd
@@ -2,7 +2,7 @@ Ddoc
 
 $(SPEC_S Floating Point,
 
-$(H3 Floating Point Intermediate Values)
+$(H3 $(LNAME2 fp_intermediate_values, Floating Point Intermediate Values))
 
 	$(P On many computers, greater
 	precision operations do not take any longer than lesser
@@ -41,7 +41,7 @@ $(H3 Floating Point Intermediate Values)
 	    $(LI data and function argument compatibility with C)
 	)
 
-$(H3 Floating Point Constant Folding)
+$(H3 $(LNAME2 fp_const_folding, Floating Point Constant Folding))
 
 	$(P Regardless of the type of the operands, floating point
 	constant folding is done in $(D real) or greater precision.
@@ -91,7 +91,7 @@ writeln(f - 0.2);
 	folding, therefore the results of floating point calculations may differ
 	depending on those settings.)
 
-$(H3 Rounding Control)
+$(H3 $(LNAME2 rounding_control, Rounding Control))
 
 	$(P IEEE 754 floating point arithmetic includes the ability to set 4
 	different rounding modes.
@@ -105,7 +105,7 @@ $(H3 Rounding Control)
 	)
 
 
-$(H3 Exception Flags)
+$(H3 $(LNAME2 esception_flags, Exception Flags))
 
 	$(P IEEE 754 floating point arithmetic can set several flags based on what
 	happened with a

--- a/spec/function.dd
+++ b/spec/function.dd
@@ -1158,7 +1158,7 @@ $(H3 $(LNAME2 variadic, Variadic Functions))
         )
 
 
-$(H4 C-style Variadic Functions)
+$(H4 $(LNAME2 c_style_cariadic_functions, C-style Variadic Functions))
 
         A C-style variadic function is declared as taking
         a parameter of ... after the required function parameters.
@@ -1217,7 +1217,7 @@ void foo(int x, int y, ...)
 ------
 
 
-$(H4 D-style Variadic Functions)
+$(H4 $(LNAME2 d_style_variadic_functions, D-style Variadic Functions))
 
         Variadic functions with argument and type info are declared as taking
         a parameter of ... after the required function parameters.
@@ -1336,7 +1336,7 @@ Bar
 ------
 
 
-$(H4 Typesafe Variadic Functions)
+$(H4 $(LNAME2 typesafe_variadic_functions, Typesafe Variadic Functions))
 
         $(P Typesafe variadic functions are used when the variable argument
         portion of the arguments are used to construct an array or
@@ -1449,7 +1449,7 @@ int[] x;
 test(x);    // error, type mismatch
 ------
 
-$(H4 Lazy Variadic Functions)
+$(H4 $(LNAME2 lazy_variadic_functions, Lazy Variadic Functions))
 
         $(P If the variadic parameter is an array of delegates
         with no parameters:

--- a/spec/garbage.dd
+++ b/spec/garbage.dd
@@ -115,7 +115,7 @@ $(SPEC_S Garbage Collection,
 	to allow its use in scenarios where the use of GC infrastructure is not possible.
 	)
 
-$(H2 How Garbage Collection Works)
+$(H2 $(LNAME2 how_gc_works, How Garbage Collection Works))
 
 	$(P The GC works by:)
 
@@ -145,7 +145,7 @@ $(H2 How Garbage Collection Works)
 	$(LI Returning the current thread to whatever work it was doing.)
 	)
 
-$(H2 Interfacing Garbage Collected Objects With Foreign Code)
+$(H2 $(LNAME2 gc_foreign_obj, Interfacing Garbage Collected Objects With Foreign Code))
 
 	$(P The garbage collector looks for roots in:)
 	$(OL
@@ -175,7 +175,7 @@ $(H2 Interfacing Garbage Collected Objects With Foreign Code)
 	)
 	)
 
-$(H2 Pointers and the Garbage Collector)
+$(H2 $(LNAME2 pointers_and_gc, Pointers and the Garbage Collector))
 
 	$(P Pointers in D can be broadly divided into two categories: Those that
 	point to garbage collected memory, and those that do not. Examples
@@ -335,7 +335,7 @@ char[] q = p[3..6];
 	some low level work.
 	)
 
-$(H2 Working with the Garbage Collector)
+$(H2 $(LNAME2 working_with_the_gc, Working with the Garbage Collector))
 
 	$(P Garbage collection doesn't solve every memory deallocation problem.
 	For
@@ -350,7 +350,7 @@ $(H2 Working with the Garbage Collector)
 	stack to be nulled because new stack frames are initialized anyway.
 	)
 
-$(H2 Object Pinning and a Moving Garbage Collector)
+$(H2 $(LNAME2 obj_pinning_and_gc, Object Pinning and a Moving Garbage Collector))
 
 	$(P Although D does not currently use a moving garbage collector, by following
 	the rules listed above one can be implemented. No special action is required
@@ -359,7 +359,7 @@ $(H2 Object Pinning and a Moving Garbage Collector)
 	All other objects will be automatically pinned.
 	)
 
-$(H2 D Operations That Involve the Garbage Collector)
+$(H2 D $(LNAME2 op_involving_gc, Operations That Involve the Garbage Collector))
 
 	$(P Some sections of code may need to avoid using the garbage collector.
 	The following constructs may allocate memory using the garbage collector:
@@ -380,7 +380,7 @@ $(H2 D Operations That Involve the Garbage Collector)
 	$(LI An $(GLINK2 expression, AssertExpression) that fails its condition)
 	)
 
-$(H2 Configuring the Garbage Collector)
+$(H2 $(LNAME2 gc_config, Configuring the Garbage Collector))
 
     $(P Since version 2.067, The garbage collector can now be configured
         through the command line, the environment or by options embedded
@@ -433,7 +433,7 @@ $(H2 Configuring the Garbage Collector)
         options specified through the environment or embedded in the executable.
     )
 
-$(H2 References)
+$(H2 $(LNAME2 references, References))
 
 	$(UL
 	$(LI $(LINK2 https://en.wikipedia.org/wiki/Garbage_collection_$(PERCENT)28computer_science$(PERCENT)29, Wikipedia))

--- a/spec/template-mixin.dd
+++ b/spec/template-mixin.dd
@@ -191,7 +191,7 @@ void test()
 }
 ------
 
-$(H2 Mixin Scope)
+$(H2 $(LNAME2 mixin_scope, Mixin Scope))
 
         The declarations in a mixin are $(SINGLEQUOTE imported) into the surrounding
         scope. If the name of a declaration in a mixin is the same

--- a/spec/template.dd
+++ b/spec/template.dd
@@ -54,7 +54,7 @@ $(GNAME TemplateParameter):
         $(I TemplateParameter) in case one is not supplied.
     )
 
-$(H2 Explicit Template Instantiation)
+$(H2 $(LNAME2 explicit_tmp_instantiation, Explicit Template Instantiation))
 
     $(P Templates are explicitly instantiated with:
     )
@@ -188,7 +188,7 @@ $(GNAME TemplateSingleArgument):
         ------
     )
 
-$(H2 Instantiation Scope)
+$(H2 $(LNAME2 instantiation_scope, Instantiation Scope))
 
     $(P $(I TemplateInstantance)s are always performed in the scope of where
         the $(I TemplateDeclaration) is declared, with the addition of the
@@ -328,7 +328,7 @@ $(GNAME TemplateTypeParameterDefault):
     $(D =) $(GLINK2 declaration, Type)
 )
 
-$(H3 Specialization)
+$(H3 $(LNAME2 parameters_specialization, Specialization))
 
     $(P Templates may be specialized for particular types of arguments
         by following the template parameter identifier with a : and the
@@ -357,7 +357,7 @@ $(H3 Specialization)
     )
 
 
-$(H2 Template This Parameters)
+$(H2 $(LNAME2 template_this_parameter, Template This Parameters))
 
 $(GRAMMAR
 $(GNAME TemplateThisParameter):
@@ -457,7 +457,7 @@ immutable(S)
         ---
     )
 
-$(H2 Template Value Parameters)
+$(H2 $(LNAME2 template_value_parameter, Template Value Parameters))
 
 $(GRAMMAR
 $(GNAME TemplateValueParameter):
@@ -659,7 +659,7 @@ $(GNAME TemplateAliasParameterDefault):
         )
     )
 
-$(H3 Typed alias parameters)
+$(H3 $(LNAME2 typed_alias_op, Typed alias parameters))
 
     $(P Alias parameters can also be typed.
         These parameters will accept symbols of that type:
@@ -674,7 +674,7 @@ $(H3 Typed alias parameters)
         ------
     )
 
-$(H3 Specialization)
+$(H3 $(LNAME2 alias_parameter_specialization, Specialization))
 
     $(P Alias parameters can accept both literals and user-defined type symbols,
         but they are less specialized than the matches to type parameters and
@@ -826,7 +826,7 @@ a
         See also: $(FULL_XREF functional, partial)
     )
 
-$(H3 Specialization)
+$(H3 $(LNAME2 variadic_template_specialization, Specialization))
 
     $(P If both a template with a tuple parameter and a template
         without a tuple parameter exactly match a template instantiation,
@@ -849,7 +849,7 @@ $(H3 Specialization)
         ----
     )
 
-$(H2 Template Parameter Default Values)
+$(H2 $(LNAME2 template_parameter_def_values, Template Parameter Default Values))
 
     $(P Trailing template parameters can be given default values:
 
@@ -863,7 +863,7 @@ $(H2 Template Parameter Default Values)
         ------
     )
 
-$(H2 Implicit Template Properties)
+$(H2 $(LNAME2 implicit_template_properties, Implicit Template Properties))
 
     $(P If a template has exactly one member in it, and the name of that
         member is the same as the template name, that member is assumed
@@ -882,7 +882,7 @@ $(H2 Implicit Template Properties)
         ------
     )
 
-$(H2 Template Constructors)
+$(H2 $(LNAME2 template_ctors, Template Constructors))
 
 $(GRAMMAR
 $(GNAME ConstructorTemplate):
@@ -893,7 +893,7 @@ $(GNAME ConstructorTemplate):
     $(P Templates can be used to form constructors for classes  and structs.
     )
 
-$(H2 Aggregate Templates)
+$(H2 $(LNAME2 aggregate_templates, Aggregate Templates))
 
 $(GRAMMAR
 $(GNAME ClassTemplateDeclaration):
@@ -1299,7 +1299,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
         ---
     )
 
-    $(H3 Limitation:)
+    $(H3 $(LNAME2 nested_template_limitation, Limitation:))
 
     $(P Currently nested templates can capture at most one context. As a typical
         example, non-static template member functions cannot take local symbol
@@ -1344,7 +1344,7 @@ $(H2 $(LNAME2 nested-templates, Nested Templates))
         inner context.
     )
 
-$(H2 Recursive Templates)
+$(H2 $(LNAME2 recursive_templates, Recursive Templates))
 
     $(P Template features can be combined to produce some interesting
         effects, such as compile time evaluation of non-trivial functions.
@@ -1368,7 +1368,7 @@ $(H2 Recursive Templates)
         ------
     )
 
-$(H2 Template Constraints)
+$(H2 $(LNAME2 template_cosntraints, Template Constraints))
 
 $(GRAMMAR
 $(GNAME Constraint):
@@ -1400,7 +1400,7 @@ $(GNAME Constraint):
     )
 
 
-$(H2 Limitations)
+$(H2 $(LNAME2 limitations, Limitations))
 
     $(P Templates cannot be used to add non-static members or
         virtual functions to classes.

--- a/spec/version.dd
+++ b/spec/version.dd
@@ -410,7 +410,7 @@ debug:
 ------
 
 
-$(H3 Debug Specification)
+$(H3 $(LNAME2 debug_specification, Debug Specification))
 
 $(GRAMMAR
 $(GNAME DebugSpecification):


### PR DESCRIPTION
add more missing anchors, from "functions to "Embedded Documentation"

following the order in the site menu is remaining to do:
 -  operator overloading: DAutotestfailure because ?
 -  Const and Immutable: const3.dd, need rewritting to allow LNAME, paragraphs are surrounded with $(SECTION ...), the markup style is not super friendly
 -  _Interfacing to C_ to _Vector Extensions_.
 -  maybe the pages that are not located in the spec folder.

If acceptable, this PR can be merged as it or you can wait for the remaining pages to be processed.