### PR TITLE
Link fixes for C++ interface

### DIFF
--- a/spec/cpp_interface.dd
+++ b/spec/cpp_interface.dd
@@ -5,9 +5,8 @@ $(SPEC_S Interfacing to C++,
     $(P This document specifies how to interface with C++ directly.)
 
     $(P It is also possible to indirectly interface with C++ code, either
-    through a $(DDLINK interfaceToC, Interfacing to C, C interface) or a
-    $(DPLLINK COM.html, COM interface), specified in their respective
-    documents.)
+    through a $(DDLINK spec/interfaceToC, Interfacing to C, C interface) or a
+    COM interface.)
 
 $(H2 The General Idea)
 


### PR DESCRIPTION
The "COM interface" link is broken. There is no point in fixing it at the moment, though, since there is no actual content at the wiki page it's meant to target. Instead, I just removed the link.

The "C interface" link works on **dlang.org**, but wasn't on my local build because it was missing the `spec/` prefix. So, I fixed that too.