### PR TITLE
use https for internal documentation links

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -290,7 +290,7 @@ _=
 PC=$(TC p, $1, $+)
 _=
 
-PHOBOS=$(SPANC phobos, $(AHTTP dlang.org/phobos/std_$1.html#$2, $(TAIL $+)))
+PHOBOS=$(SPANC phobos, $(AHTTPS dlang.org/phobos/std_$1.html#$2, $(TAIL $+)))
 PHOBOSSRC=$(SPANC phobos_src, $(AHTTPS github.com/D-Programming-Language/phobos/blob/master/$0, $0))
 _=
 
@@ -458,9 +458,9 @@ WIKI=$(TITLE)
 _=
 
 XREF=$(XREF2 $1, $2, $(D std.$1.$2))
-XREF2=$(SPANC libref, $(AHTTP dlang.org/phobos/std_$1.html#$2, $(TAIL $+)))
+XREF2=$(SPANC libref, $(AHTTPS dlang.org/phobos/std_$1.html#$2, $(TAIL $+)))
 XREF_PACK=$(XREF_PACK_NAMED $1, $2, $3, $(D std.$1.$2.$3))
-XREF_PACK_NAMED=$(SPANC libref, $(AHTTP dlang.org/phobos/std_$1_$2.html#$3, $4))
+XREF_PACK_NAMED=$(SPANC libref, $(AHTTPS dlang.org/phobos/std_$1_$2.html#$3, $4))
 _=
 
 YELLOW=$(SPANC yellow, $0)


### PR DESCRIPTION
why don't we use `https` for the links within phobos's documentation?