### PR TITLE
Implement REF_ALTTEXT macro for DDox

### DIFF
--- a/std-ddox.ddoc
+++ b/std-ddox.ddoc
@@ -8,5 +8,6 @@ ROOT_DIR=/
 _=
 
 REF=$(D $2$(DOT_PREFIXED_SKIP $+).$1)
+REF_ALTTEXT=$1 ($(REF $+))
 MREF=$(D $1$(DOT_PREFIXED $+))
 _=


### PR DESCRIPTION
For DDoc,
```
$(REF_ALTTEXT writeln, File.writeln, std, stdio)
```
expands to
```
<a href="std_stdio.html#.File.writeln">writeln</a>
```
which relies on the fact that `File.writeln` is part of the URL. To provide identical functionality for DDox, it would have to expand to:
```
a href="/library/std/stdio/File/writeln>writeln</a>
```
`REF` handles this by expanding to `std.stdio.File.writeln` and letting DDox recognize it as a symbol path, but I'm not aware of an equivalent feature in DDox that works like `REF_ALTTEXT`.

This patch makes it expand to:
```
writeln (std.stdio.File.writeln)
```
It's not ideal but it's an improvement over the broken output it currently generates.
