### PR TITLE
fix compile error

### DIFF
--- a/spec/declaration.dd
+++ b/spec/declaration.dd
@@ -697,7 +697,7 @@ void main()
     // variables, because the 'ref' only applies to the return value itself,
     // not to any subsequent variable created from it:
     auto x = func2();
-    static assert(typeof(x) == int); // N.B.: *not* ref(int);
+    static assert(is(typeof(x) == int)); // N.B.: *not* ref(int);
                                      // there is no such type as ref(int).
     x++;
     assert(x == 3);


### PR DESCRIPTION
ref2.d
```d
import std.stdio;

ref int func2()
{
    static int y = 0;
    writeln("y \t" , y);

    return y;
}

void main()
{
    func2() = 2; // The return value of func2() can be modified.
    assert(func2() == 2);

    auto x = func2();
    pragma(msg, typeof(x));
    static assert(is(typeof(x) == int));
    static assert(typeof(x) == int); // why not work ???

    x++;
    writeln("x \t", x);
    assert(x == 3);
    assert(func2() == 2);
}
```

```
dmd ref2.d
ref2.d(19): Error: found ')' when expecting '.' following int
ref2.d(19): Error: found ';' when expecting identifier following 'int.'
ref2.d(21): Error: found 'x' when expecting ')'
ref2.d(21): Error: found '++' when expecting ';'
```