### PR TITLE
all language reference should link to spec.html NOT intro.html

### DIFF
--- a/dlang.org.ddoc
+++ b/dlang.org.ddoc
@@ -233,7 +233,7 @@ $(SUBMENU
 )
 NAVIGATION_DOCUMENTATION=
 $(SUBMENU
-    $(ROOT_DIR)spec/intro.html, Language Reference,
+    $(ROOT_DIR)spec/spec.html, Language Reference,
     $(ROOT_DIR)phobos/index.html, Library Reference,
     $(ROOT_DIR)comparison.html, Feature Overview,
     $(ROOT_DIR)dmd-windows.html, DMD Manual,

--- a/dpl-docs/views/layout.dt
+++ b/dpl-docs/views/layout.dt
@@ -50,7 +50,7 @@ html(lang='en-US')
                   span Documentation
                 ul
                   li
-                    a(href="#{root_dir}spec/intro.html")Language Reference
+                    a(href="#{root_dir}spec/spec.html")Language Reference
                   li
                     a(href="#{root_dir}phobos/index.html") Library Reference
                   li

--- a/getstarted.dd
+++ b/getstarted.dd
@@ -39,7 +39,7 @@ Getting Started,
   $(LI Choose an $(LINK2 https://wiki.dlang.org/IDEs, $(B IDE)) or set up your favorite
   $(LINK2 https://wiki.dlang.org/Editors, $(B Editor)).
   )
-  $(LI Read the official $(LINK2 spec/intro.html, $(B Language))
+  $(LI Read the official $(LINK2 spec/spec.html, $(B Language))
   and $(LINK2 https://dlang.org/phobos/index.html, $(B Standard Library)) references. 
   )
   $(LI Browse the $(LINK2 https://code.dlang.org/, $(B Dub Repository)), hosting 

--- a/index.dd
+++ b/index.dd
@@ -119,7 +119,7 @@ $(DIVC boxes,
         )
         $(TOUR book, Documentation,
             $(P Refer to the documentation for the
-                $(LINK2 $(ROOT_DIR)spec/intro.html, language) and for
+                $(LINK2 $(ROOT_DIR)spec/spec.html, language) and for
                 $(LINK2 $(ROOT_DIR)phobos/index.html, phobos), D's standard
                 library. The
                 $(LINK2 $(ROOT_DIR)dmd-windows.html, DMD manual) tells you how


### PR DESCRIPTION
for spec.html we can see contents of spec and download link to *.pdf and *.mobi